### PR TITLE
fix sourceUri mapping

### DIFF
--- a/src/main/scala/dpla/ebookapi/v1/ebooks/DplaMapFields.scala
+++ b/src/main/scala/dpla/ebookapi/v1/ebooks/DplaMapFields.scala
@@ -20,14 +20,6 @@ object DplaMapFields {
 
   private final val fields = Seq(
     DplaField(
-      name = "dataProvider",
-      fieldType = URLField,
-      searchable = true,
-      facetable = true,
-      elasticSearchDefault = "sourceUri",
-      elasticSearchNotAnalyzed = Some("sourceUri")
-    ),
-    DplaField(
       name = "isShownAt",
       fieldType = URLField,
       searchable = true,
@@ -42,6 +34,14 @@ object DplaMapFields {
       facetable = false,
       elasticSearchDefault = "payloadUri",
       elasticSearchNotAnalyzed = Some("payloadUri")
+    ),
+    DplaField(
+      name = "provider.@id",
+      fieldType = URLField,
+      searchable = true,
+      facetable = true,
+      elasticSearchDefault = "sourceUri",
+      elasticSearchNotAnalyzed = Some("sourceUri")
     ),
     DplaField(
       name = "sourceResource.creator",

--- a/src/main/scala/dpla/ebookapi/v1/ebooks/JsonFormats.scala
+++ b/src/main/scala/dpla/ebookapi/v1/ebooks/JsonFormats.scala
@@ -30,10 +30,12 @@ object JsonFormats extends DefaultJsonProtocol with JsonFieldReader {
 
       filterIfEmpty(JsObject(
         "id" -> ebook.id.toJson,
-        "dataProvider" -> ebook.sourceUri.toJson,
         "ingestType" -> JsString("ebook"),
         "isShownAt" -> ebook.itemUri.toJson,
         "object" -> ebook.payloadUri.toJson,
+        "provider" -> filterIfEmpty(JsObject(
+          "@id" -> ebook.sourceUri.toJson,
+        )),
         "sourceResource" -> filterIfEmpty(JsObject(
           "creator" -> ebook.author.toJson,
           "date" -> filterIfEmpty(JsObject(
@@ -91,7 +93,7 @@ object JsonFormats extends DefaultJsonProtocol with JsonFieldReader {
   }
 
   /** In an ElasticSearch response, facets look something like this:
-   *  {"aggregations": {"dataProvider": {"buckets": [...]}}, "sourceResource.publisher": {"buckets": [...]}}}
+   *  {"aggregations": {"provider.@id": {"buckets": [...]}}, "sourceResource.publisher": {"buckets": [...]}}}
    *  You therefore have to read the keys of the "aggregation" object to get the facet field names.
    */
   implicit object FacetListFormat extends RootJsonFormat[FacetList] {

--- a/src/test/resources/elasticSearchEbookList.json
+++ b/src/test/resources/elasticSearchEbookList.json
@@ -27,7 +27,7 @@
   "timed_out":false,
   "took":6,
   "aggregations" : {
-    "dataProvider": {
+    "provider.@id": {
       "doc_count_error_upper_bound": 0,
       "sum_other_doc_count": 0,
       "buckets": [

--- a/src/test/scala/dpla/ebookapi/v1/ebooks/DplaMapFieldsTest.scala
+++ b/src/test/scala/dpla/ebookapi/v1/ebooks/DplaMapFieldsTest.scala
@@ -8,9 +8,9 @@ class DplaMapFieldsTest extends AnyWordSpec with Matchers {
   "DplaMapFieldsTest" should {
     "map DPLA MAP fields to ElasticSearch fields" in {
       val dplaFields = Seq(
-        "dataProvider",
         "isShownAt",
         "object",
+        "provider.@id",
         "sourceResource.creator",
         "sourceResource.date.displayDate",
         "sourceResource.description",
@@ -41,9 +41,9 @@ class DplaMapFieldsTest extends AnyWordSpec with Matchers {
 
     "map DPLA MAP fields to exact match ElasticSearch fields" in {
       val dplaFields = Seq(
-        "dataProvider",
         "isShownAt",
         "object",
+        "provider.@id",
         "sourceResource.creator",
         "sourceResource.date.displayDate",
         "sourceResource.description",

--- a/src/test/scala/dpla/ebookapi/v1/ebooks/EbookListMappingTest.scala
+++ b/src/test/scala/dpla/ebookapi/v1/ebooks/EbookListMappingTest.scala
@@ -56,7 +56,7 @@ class EbookListMappingTest extends AnyWordSpec with Matchers with JsonFieldReade
     }
 
     "map all facets" in {
-      val expected = Seq("dataProvider", "sourceResource.creator")
+      val expected = Seq("provider.@id", "sourceResource.creator")
       val parent = readObject(ebookList, "facets")
       val children = parent.get.fields.keys
       children should contain allElementsOf expected
@@ -64,14 +64,14 @@ class EbookListMappingTest extends AnyWordSpec with Matchers with JsonFieldReade
 
     "map facet terms" in {
       val expected = Some("http://standardebooks.org")
-      val firstTerm = readObjectArray(ebookList, "facets", "dataProvider", "terms").head
+      val firstTerm = readObjectArray(ebookList, "facets", "provider.@id", "terms").head
       val traversed = readString(firstTerm, "term")
       assert(traversed == expected)
     }
 
     "map facet counts" in {
       val expected = Some(590)
-      val firstTerm = readObjectArray(ebookList, "facets", "dataProvider", "terms").head
+      val firstTerm = readObjectArray(ebookList, "facets", "provider.@id", "terms").head
       val traversed = readInt(firstTerm, "count")
       assert(traversed == expected)
     }

--- a/src/test/scala/dpla/ebookapi/v1/ebooks/ElasticSearchQueryBuilderTest.scala
+++ b/src/test/scala/dpla/ebookapi/v1/ebooks/ElasticSearchQueryBuilderTest.scala
@@ -20,7 +20,7 @@ class ElasticSearchQueryBuilderTest extends AnyWordSpec with Matchers with Priva
 
   val detailQueryParams: SearchParams = SearchParams(
     exactFieldMatch = false,
-    facets = Some(Seq("dataProvider", "sourceResource.publisher", "sourceResource.subject.name")),
+    facets = Some(Seq("provider.@id", "sourceResource.publisher", "sourceResource.subject.name")),
     facetSize = 100,
     filters = Seq(FieldFilter("sourceResource.subject.name", "adventure")),
     page = 3,
@@ -117,7 +117,7 @@ class ElasticSearchQueryBuilderTest extends AnyWordSpec with Matchers with Priva
     "handle multiple field searches" in {
       val filters = Seq(
         FieldFilter("sourceResource.subject.name", "london"),
-        FieldFilter("dataProvider", "http://standardebooks.org")
+        FieldFilter("provider.@id", "http://standardebooks.org")
       )
       val params = minSearchParams.copy(filters=filters)
       val query = ElasticSearchQueryBuilder.composeQuery(params).asJsObject
@@ -189,7 +189,7 @@ class ElasticSearchQueryBuilderTest extends AnyWordSpec with Matchers with Priva
     }
 
     "include all facets" in {
-      val expected = Seq("dataProvider", "sourceResource.publisher", "sourceResource.subject.name")
+      val expected = Seq("provider.@id", "sourceResource.publisher", "sourceResource.subject.name")
       val parent = readObject(detailQuery, "aggs")
       val fieldNames = parent.get.fields.keys
       fieldNames should contain allElementsOf expected

--- a/src/test/scala/dpla/ebookapi/v1/ebooks/ParamValidationTest.scala
+++ b/src/test/scala/dpla/ebookapi/v1/ebooks/ParamValidationTest.scala
@@ -110,30 +110,30 @@ class ParamValidationTest extends AnyWordSpec with Matchers with ScalatestRouteT
     }
   }
 
-  "dataProvider validator" should {
+  "provider id validator" should {
     "handle empty param" in {
       val expected = None
       val request = Get("/v1/ebooks")
 
       request ~> Route.seal(routes) ~> check {
-        elasticSearchClient.getLastParams.filters.find(_.fieldName == "dataProvider") shouldEqual expected
+        elasticSearchClient.getLastParams.filters.find(_.fieldName == "provider.@id") shouldEqual expected
       }
     }
 
     "accept valid param" in {
       val given = "https://standardebooks.org"
       val expected = Some("https://standardebooks.org")
-      val request = Get(s"/v1/ebooks?dataProvider=$given")
+      val request = Get(s"/v1/ebooks?provider.@id=$given")
 
       request ~> Route.seal(routes) ~> check {
-        elasticSearchClient.getLastParams.filters.find(_.fieldName == "dataProvider")
+        elasticSearchClient.getLastParams.filters.find(_.fieldName == "provider.@id")
           .map(_.value) shouldEqual expected
       }
     }
 
     "reject invalid URL" in {
       val given = "standardebooks"
-      val request = Get(s"/v1/ebooks?dataProvider=$given")
+      val request = Get(s"/v1/ebooks?provider.@id=$given")
 
       request ~> Route.seal(routes) ~> check {
         status shouldEqual StatusCodes.BadRequest
@@ -263,8 +263,8 @@ class ParamValidationTest extends AnyWordSpec with Matchers with ScalatestRouteT
     }
 
     "accept valid param" in {
-      val given = "dataProvider,sourceResource.creator"
-      val expected = Some(Seq("dataProvider", "sourceResource.creator"))
+      val given = "provider.@id,sourceResource.creator"
+      val expected = Some(Seq("provider.@id", "sourceResource.creator"))
       val request = Get(s"/v1/ebooks?facets=$given")
 
       request ~> Route.seal(routes) ~> check {

--- a/src/test/scala/dpla/ebookapi/v1/ebooks/SingleEbookMappingTest.scala
+++ b/src/test/scala/dpla/ebookapi/v1/ebooks/SingleEbookMappingTest.scala
@@ -100,7 +100,7 @@ class SingleEbookMappingTest extends AnyWordSpec with Matchers with JsonFieldRea
 
     "map sourceUri" in {
       val expected = "http://standardebooks.org"
-      val traversed = readString(firstDoc, "dataProvider").getOrElse("NOT FOUND")
+      val traversed = readString(firstDoc, "provider", "@id").getOrElse("NOT FOUND")
       assert(traversed == expected)
     }
 
@@ -175,7 +175,7 @@ class SingleEbookMappingTest extends AnyWordSpec with Matchers with JsonFieldRea
     "ignore empty sourceUri" in {
       val parent = minFirstDoc
       val fieldNames = parent.fields.keys
-      fieldNames should not contain "dataProvider"
+      fieldNames should not contain "provider.@id"
     }
 
     "ignore empty subtitle" in {


### PR DESCRIPTION
Map the ElasticSearch field `sourceUri` to the DPLA MAP field `provider.@id` instead of `dataProvider`.