### PR TITLE
add op param

### DIFF
--- a/src/main/scala/dpla/ebookapi/v1/ebooks/ParamValidator.scala
+++ b/src/main/scala/dpla/ebookapi/v1/ebooks/ParamValidator.scala
@@ -24,6 +24,7 @@ case class SearchParams(
                          facetSize: Int,
                          fields: Option[Seq[String]],
                          filters: Seq[FieldFilter],
+                         op: String,
                          page: Int,
                          pageSize: Int,
                          q: Option[String]
@@ -92,6 +93,7 @@ object ParamValidator extends DplaMapFields {
   private val defaultFacetSize: Int = 50
   private val minFacetSize: Int = 0
   private val maxFacetSize: Int = 2000
+  private val defaultOp: String = "AND"
   private val defaultPage: Int = 1
   private val minPage: Int = 1
   private val maxPage: Int = 1000
@@ -106,6 +108,7 @@ object ParamValidator extends DplaMapFields {
       "facets",
       "facet_size",
       "fields",
+      "op",
       "page",
       "page_size",
       "q"
@@ -163,6 +166,7 @@ object ParamValidator extends DplaMapFields {
           facetSize = getValid(rawParams, "facet_size", validInt).getOrElse(defaultFacetSize),
           fields = getValid(rawParams, "fields", validFields),
           filters = filters,
+          op = getValid(rawParams, "op", validAndOr).getOrElse(defaultOp),
           page = getValid(rawParams, "page", validInt).getOrElse(defaultPage),
           pageSize = getValid(rawParams, "page_size", validInt).getOrElse(defaultPageSize),
           q = getValid(rawParams, "q", validText)
@@ -270,5 +274,11 @@ object ParamValidator extends DplaMapFields {
       case Success(_) => url // return value with leading & trailing quotation marks in tact
       case Failure(_) => throw ValidationException(s"$param must be a valid URL")
     }
+  }
+
+  // Must be 'AND' or 'OR'
+  private def validAndOr(string: String, param: String): String = {
+    if (string == "AND" || string == "OR") string
+    else throw ValidationException(s"$param must be 'AND' or 'OR'")
   }
 }

--- a/src/test/scala/dpla/ebookapi/v1/ebooks/unit/ElasticSearchQueryBuilderTest.scala
+++ b/src/test/scala/dpla/ebookapi/v1/ebooks/unit/ElasticSearchQueryBuilderTest.scala
@@ -30,6 +30,7 @@ class ElasticSearchQueryBuilderTest extends AnyWordSpec with Matchers with Priva
     facetSize = 100,
     fields = None,
     filters = Seq[FieldFilter](),
+    op = "AND",
     page = 3,
     pageSize = 20,
     q = None
@@ -43,6 +44,7 @@ class ElasticSearchQueryBuilderTest extends AnyWordSpec with Matchers with Priva
     facetSize = 100,
     fields = Some(Seq("sourceResource.title")),
     filters = Seq(FieldFilter("sourceResource.subject.name", "adventure")),
+    op = "AND",
     page = 3,
     pageSize = 20,
     q = Some("dogs")
@@ -199,6 +201,24 @@ class ElasticSearchQueryBuilderTest extends AnyWordSpec with Matchers with Priva
         val traversed = readString(queryTerm, "genre.not_analyzed")
         assert(traversed == expected)
       }
+    }
+  }
+
+  "op query builder" should {
+    "set must for AND" in {
+      val expected = "must"
+      val parent = readObject(detailQuery, "query", "bool")
+      val fieldNames = parent.get.fields.keys
+      fieldNames should contain only expected
+    }
+
+    "set should for OR" in  {
+      val expected = "should"
+      val params = detailSearchParams.copy(op="OR")
+      val query = getJsQuery(params)
+      val parent = readObject(query, "query", "bool")
+      val fieldNames = parent.get.fields.keys
+      fieldNames should contain only expected
     }
   }
 

--- a/src/test/scala/dpla/ebookapi/v1/ebooks/unit/ParamValidationTest.scala
+++ b/src/test/scala/dpla/ebookapi/v1/ebooks/unit/ParamValidationTest.scala
@@ -399,6 +399,31 @@ class ParamValidationTest extends AnyWordSpec with Matchers with BeforeAndAfterA
     }
   }
 
+  "op validator" should {
+    "handle empty param" in {
+      val expected = "AND"
+      paramValidator ! ValidateSearchParams(Map(), probe.ref)
+      val msg = probe.expectMessageType[ValidSearchParams]
+      msg.searchParams.op shouldEqual expected
+    }
+
+    "accept valid param" in {
+      val given = "OR"
+      val expected = "OR"
+      val params = Map("op" -> given)
+      paramValidator ! ValidateSearchParams(params, probe.ref)
+      val msg = probe.expectMessageType[ValidSearchParams]
+      msg.searchParams.op shouldEqual expected
+    }
+
+    "reject invalid param" in {
+      val given = "or"
+      val params = Map("op" -> given)
+      paramValidator ! ValidateSearchParams(params, probe.ref)
+      probe.expectMessageType[InvalidParams]
+    }
+  }
+
   "page validator" should {
     "handle empty param" in {
       val expected = 1


### PR DESCRIPTION
Users can set the param `op` to be `AND` or `OR`.  This param works the same way in the cultural heritage API.