### PR TITLE
cleanup all uses of fake api key in tests

### DIFF
--- a/src/test/scala/dpla/ebookapi/helpers/Utils.scala
+++ b/src/test/scala/dpla/ebookapi/helpers/Utils.scala
@@ -1,0 +1,6 @@
+package dpla.ebookapi.helpers
+
+object Utils {
+  // This is not a real API key, used for testing only.
+  val fakeApiKey = "08e3918eeb8bf4469924f062072459a8"
+}

--- a/src/test/scala/dpla/ebookapi/v1/authentication/AuthParamValidatorTest.scala
+++ b/src/test/scala/dpla/ebookapi/v1/authentication/AuthParamValidatorTest.scala
@@ -2,6 +2,7 @@ package dpla.ebookapi.v1.authentication
 
 import akka.actor.testkit.typed.scaladsl.{ActorTestKit, TestProbe}
 import akka.actor.typed.ActorRef
+import dpla.ebookapi.helpers.Utils.fakeApiKey
 import dpla.ebookapi.v1.authentication.AuthProtocol.{AuthenticationResponse, IntermediateAuthResult, InvalidApiKey, InvalidEmail, RawApiKey, RawEmail, ValidApiKey, ValidEmail}
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.matchers.should.Matchers
@@ -15,8 +16,6 @@ class AuthParamValidatorTest extends AnyWordSpec with Matchers
 
   lazy val testKit: ActorTestKit = ActorTestKit()
   override def afterAll(): Unit = testKit.shutdownTestKit()
-
-  val baseParams = Map("api_key" -> "08e3918eeb8bf4469924f062072459a8")
 
   val interProbe: TestProbe[IntermediateAuthResult] =
     testKit.createTestProbe[IntermediateAuthResult]
@@ -63,7 +62,7 @@ class AuthParamValidatorTest extends AnyWordSpec with Matchers
   "api key validator" should {
 
     "accept valid api key" in {
-      val given = "08e3918eeb8bf4469924f062072459a8"
+      val given = fakeApiKey
       paramValidator ! RawApiKey(given, replyProbe.ref)
       interProbe.expectMessageType[ValidApiKey]
     }

--- a/src/test/scala/dpla/ebookapi/v1/authentication/MockPostgresClientDisabled.scala
+++ b/src/test/scala/dpla/ebookapi/v1/authentication/MockPostgresClientDisabled.scala
@@ -2,6 +2,7 @@ package dpla.ebookapi.v1.authentication
 
 import akka.actor.typed.Behavior
 import akka.actor.typed.scaladsl.Behaviors
+import dpla.ebookapi.helpers.Utils.fakeApiKey
 import dpla.ebookapi.v1.authentication
 import dpla.ebookapi.v1.authentication.AuthProtocol.{AccountCreated, AccountFound, IntermediateAuthResult, ValidApiKey, ValidEmail}
 
@@ -9,7 +10,7 @@ object MockPostgresClientDisabled {
 
   private val account = authentication.Account(
     id = 1,
-    key = "08e3918eeb8bf4469924f062072459a8",
+    key = fakeApiKey,
     email = "x@example.org",
     staff = Some(false),
     enabled = Some(false)

--- a/src/test/scala/dpla/ebookapi/v1/authentication/MockPostgresClientExistingKey.scala
+++ b/src/test/scala/dpla/ebookapi/v1/authentication/MockPostgresClientExistingKey.scala
@@ -2,6 +2,7 @@ package dpla.ebookapi.v1.authentication
 
 import akka.actor.typed.Behavior
 import akka.actor.typed.scaladsl.Behaviors
+import dpla.ebookapi.helpers.Utils.fakeApiKey
 import dpla.ebookapi.v1.authentication
 import dpla.ebookapi.v1.authentication.AuthProtocol.{AccountFound, IntermediateAuthResult, ValidApiKey, ValidEmail}
 
@@ -9,7 +10,7 @@ object MockPostgresClientExistingKey {
 
   private val account = authentication.Account(
     id = 1,
-    key = "08e3918eeb8bf4469924f062072459a8",
+    key = fakeApiKey,
     email = "x@example.org",
     staff = Some(false),
     enabled = Some(true)

--- a/src/test/scala/dpla/ebookapi/v1/authentication/MockPostgresClientStaff.scala
+++ b/src/test/scala/dpla/ebookapi/v1/authentication/MockPostgresClientStaff.scala
@@ -2,6 +2,7 @@ package dpla.ebookapi.v1.authentication
 
 import akka.actor.typed.Behavior
 import akka.actor.typed.scaladsl.Behaviors
+import dpla.ebookapi.helpers.Utils.fakeApiKey
 import dpla.ebookapi.v1.authentication
 import dpla.ebookapi.v1.authentication.AuthProtocol.{AccountFound, IntermediateAuthResult, ValidApiKey}
 
@@ -9,7 +10,7 @@ object MockPostgresClientStaff {
 
   private val account = authentication.Account(
     id = 1,
-    key = "08e3918eeb8bf4469924f062072459a8",
+    key = fakeApiKey,
     email = "x@dp.la",
     staff = Some(false),
     enabled = Some(true)

--- a/src/test/scala/dpla/ebookapi/v1/authentication/MockPostgresClientSuccess.scala
+++ b/src/test/scala/dpla/ebookapi/v1/authentication/MockPostgresClientSuccess.scala
@@ -2,6 +2,7 @@ package dpla.ebookapi.v1.authentication
 
 import akka.actor.typed.Behavior
 import akka.actor.typed.scaladsl.Behaviors
+import dpla.ebookapi.helpers.Utils.fakeApiKey
 import dpla.ebookapi.v1.authentication
 import dpla.ebookapi.v1.authentication.AuthProtocol.{AccountCreated, AccountFound, IntermediateAuthResult, ValidApiKey, ValidEmail}
 
@@ -9,7 +10,7 @@ object MockPostgresClientSuccess {
 
   private val account = authentication.Account(
     id = 1,
-    key = "08e3918eeb8bf4469924f062072459a8",
+    key = fakeApiKey,
     email = "x@example.org",
     staff = Some(false),
     enabled = Some(true)

--- a/src/test/scala/dpla/ebookapi/v1/endToEnd/ElasticSearchErrorTest.scala
+++ b/src/test/scala/dpla/ebookapi/v1/endToEnd/ElasticSearchErrorTest.scala
@@ -7,6 +7,7 @@ import akka.http.scaladsl.model.headers.Accept
 import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import dpla.ebookapi.Routes
+import dpla.ebookapi.helpers.Utils.fakeApiKey
 import dpla.ebookapi.v1.analytics.AnalyticsClient
 import dpla.ebookapi.v1.analytics.AnalyticsClient.AnalyticsClientCommand
 import dpla.ebookapi.v1.authentication.AuthProtocol.AuthenticationCommand
@@ -37,9 +38,6 @@ class ElasticSearchErrorTest extends AnyWordSpec with Matchers
 
   val apiKeyRegistry: ActorRef[ApiKeyRegistryCommand] =
     MockApiKeyRegistry(testKit, authenticator)
-
-  // This is not a real API key, used for testing only.
-  val fakeApiKey = "08e3918eeb8bf4469924f062072459a8"
 
   "/v1/ebooks route" should {
     "return Teapot if ElasticSearch entity cannot be parsed" in {

--- a/src/test/scala/dpla/ebookapi/v1/endToEnd/HappyPathsTest.scala
+++ b/src/test/scala/dpla/ebookapi/v1/endToEnd/HappyPathsTest.scala
@@ -6,6 +6,7 @@ import akka.http.scaladsl.model._
 import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import dpla.ebookapi.Routes
+import dpla.ebookapi.helpers.Utils.fakeApiKey
 import dpla.ebookapi.v1.analytics.AnalyticsClient
 import dpla.ebookapi.v1.analytics.AnalyticsClient.AnalyticsClientCommand
 import dpla.ebookapi.v1.authentication.AuthProtocol.AuthenticationCommand
@@ -51,11 +52,9 @@ class HappyPathsTest extends AnyWordSpec with Matchers with ScalatestRouteTest
   lazy val routes: Route =
     new Routes(ebookRegistry, apiKeyRegistry).applicationRoutes
 
-  val apiKey = "08e3918eeb8bf4469924f062072459a8"
-
   "/v1/ebooks route" should {
     "be happy with valid user inputs and successful es response" in {
-      val request = Get(s"/v1/ebooks?page_size=100&api_key=$apiKey")
+      val request = Get(s"/v1/ebooks?page_size=100&api_key=$fakeApiKey")
 
       request ~> Route.seal(routes) ~> check {
         status shouldEqual StatusCodes.OK
@@ -87,7 +86,7 @@ class HappyPathsTest extends AnyWordSpec with Matchers with ScalatestRouteTest
 
   "/v1/ebooks/[id] route" should {
     "be happy with valid single ID and successful es response" in {
-      val request = Get(s"/v1/ebooks/wfwPJ34Bj-MaVWqX9Kac?api_key=$apiKey")
+      val request = Get(s"/v1/ebooks/wfwPJ34Bj-MaVWqX9Kac?api_key=$fakeApiKey")
 
       request ~> Route.seal(routes) ~> check {
         status shouldEqual StatusCodes.OK
@@ -114,7 +113,7 @@ class HappyPathsTest extends AnyWordSpec with Matchers with ScalatestRouteTest
         "wvwPJ34BjqMaVWqX9Kac"
       )
       val ids = idSeq.mkString(",")
-      val request = Get(s"/v1/ebooks/$ids?api_key=$apiKey")
+      val request = Get(s"/v1/ebooks/$ids?api_key=$fakeApiKey")
 
       request ~> Route.seal(routes) ~> check {
         status shouldEqual StatusCodes.OK

--- a/src/test/scala/dpla/ebookapi/v1/endToEnd/InvalidParamsTest.scala
+++ b/src/test/scala/dpla/ebookapi/v1/endToEnd/InvalidParamsTest.scala
@@ -6,6 +6,7 @@ import akka.http.scaladsl.model._
 import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import dpla.ebookapi.Routes
+import dpla.ebookapi.helpers.Utils.fakeApiKey
 import dpla.ebookapi.v1.analytics.AnalyticsClient
 import dpla.ebookapi.v1.analytics.AnalyticsClient.AnalyticsClientCommand
 import dpla.ebookapi.v1.authentication.AuthProtocol.AuthenticationCommand
@@ -46,11 +47,9 @@ class InvalidParamsTest extends AnyWordSpec with Matchers
   lazy val routes: Route =
     new Routes(ebookRegistry, apiKeyRegistry).applicationRoutes
 
-  val apiKey = "08e3918eeb8bf4469924f062072459a8"
-
   "/v1/ebooks route" should {
     "return BadRequest if params are invalid" in {
-      val request = Get(s"/v1/ebooks?page=foo&api_key=$apiKey")
+      val request = Get(s"/v1/ebooks?page=foo&api_key=$fakeApiKey")
 
       request ~> Route.seal(routes) ~> check {
         status shouldEqual StatusCodes.BadRequest
@@ -60,7 +59,7 @@ class InvalidParamsTest extends AnyWordSpec with Matchers
 
   "/v1/ebooks[id] route" should {
     "return BadRequest if id is invalid" in {
-      val request = Get(s"/v1/ebooks/<foo>?api_key=$apiKey")
+      val request = Get(s"/v1/ebooks/<foo>?api_key=$fakeApiKey")
 
       request ~> Route.seal(routes) ~> check {
         status shouldEqual StatusCodes.BadRequest
@@ -69,7 +68,7 @@ class InvalidParamsTest extends AnyWordSpec with Matchers
 
     "return BadRequest if params are invalid" in {
       val request =
-        Get(s"/v1/ebooks/R0VfVX4BfY91SSpFGqxt?foo=bar&api_key=$apiKey")
+        Get(s"/v1/ebooks/R0VfVX4BfY91SSpFGqxt?foo=bar&api_key=$fakeApiKey")
 
       request ~> Route.seal(routes) ~> check {
         status shouldEqual StatusCodes.BadRequest

--- a/src/test/scala/dpla/ebookapi/v1/endToEnd/MapperFailureTest.scala
+++ b/src/test/scala/dpla/ebookapi/v1/endToEnd/MapperFailureTest.scala
@@ -7,6 +7,7 @@ import akka.http.scaladsl.model.headers.Accept
 import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import dpla.ebookapi.Routes
+import dpla.ebookapi.helpers.Utils.fakeApiKey
 import dpla.ebookapi.v1.analytics.AnalyticsClient
 import dpla.ebookapi.v1.analytics.AnalyticsClient.AnalyticsClientCommand
 import dpla.ebookapi.v1.authentication.AuthProtocol.AuthenticationCommand
@@ -37,8 +38,6 @@ class MapperFailureTest extends AnyWordSpec with Matchers
   val apiKeyRegistry: ActorRef[ApiKeyRegistryCommand] =
     MockApiKeyRegistry(testKit, authenticator)
 
-  val apiKey = "08e3918eeb8bf4469924f062072459a8"
-
   "/v1/ebooks route" should {
 
     "return Teapot if ElasticSearch response cannot be mapped" in {
@@ -53,7 +52,7 @@ class MapperFailureTest extends AnyWordSpec with Matchers
       lazy val routes: Route =
         new Routes(ebookRegistry, apiKeyRegistry).applicationRoutes
 
-      val request = Get(s"/v1/ebooks?api_key=$apiKey")
+      val request = Get(s"/v1/ebooks?api_key=$fakeApiKey")
         .withHeaders(Accept(Seq(MediaRange(MediaTypes.`application/json`))))
 
       request ~> Route.seal(routes) ~> check {
@@ -76,7 +75,7 @@ class MapperFailureTest extends AnyWordSpec with Matchers
       lazy val routes: Route =
         new Routes(ebookRegistry, apiKeyRegistry).applicationRoutes
 
-      val request = Get(s"/v1/ebooks/R0VfVX4BfY91SSpFGqxt?api_key=$apiKey")
+      val request = Get(s"/v1/ebooks/R0VfVX4BfY91SSpFGqxt?api_key=$fakeApiKey")
         .withHeaders(Accept(Seq(MediaRange(MediaTypes.`application/json`))))
 
       request ~> Route.seal(routes) ~> check {

--- a/src/test/scala/dpla/ebookapi/v1/endToEnd/PostgresErrorTest.scala
+++ b/src/test/scala/dpla/ebookapi/v1/endToEnd/PostgresErrorTest.scala
@@ -6,6 +6,7 @@ import akka.http.scaladsl.model._
 import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import dpla.ebookapi.Routes
+import dpla.ebookapi.helpers.Utils.fakeApiKey
 import dpla.ebookapi.v1.analytics.AnalyticsClient
 import dpla.ebookapi.v1.analytics.AnalyticsClient.AnalyticsClientCommand
 import dpla.ebookapi.v1.email.EmailClient.EmailClientCommand
@@ -36,8 +37,6 @@ class PostgresErrorTest extends AnyWordSpec with Matchers
   val ebookSearch: ActorRef[SearchCommand] =
     MockEbookSearch(testKit, Some(elasticSearchClient), Some(mapper))
 
-  val apiKey = "08e3918eeb8bf4469924f062072459a8"
-
   "/v1/ebooks route" should {
     "return Teapot if Postgres errors" in {
       val postgresClient = testKit.spawn(MockPostgresClientError())
@@ -54,7 +53,7 @@ class PostgresErrorTest extends AnyWordSpec with Matchers
       lazy val routes: Route =
         new Routes(ebookRegistry, apiKeyRegistry).applicationRoutes
 
-      val request = Get(s"/v1/ebooks?api_key=$apiKey")
+      val request = Get(s"/v1/ebooks?api_key=$fakeApiKey")
 
       request ~> Route.seal(routes) ~> check {
         status shouldEqual StatusCodes.ImATeapot
@@ -78,7 +77,7 @@ class PostgresErrorTest extends AnyWordSpec with Matchers
       lazy val routes: Route =
         new Routes(ebookRegistry, apiKeyRegistry).applicationRoutes
 
-      val request = Get(s"/v1/ebooks/R0VfVX4BfY91SSpFGqxt?api_key=$apiKey")
+      val request = Get(s"/v1/ebooks/R0VfVX4BfY91SSpFGqxt?api_key=$fakeApiKey")
 
       request ~> Route.seal(routes) ~> check {
         status shouldEqual StatusCodes.ImATeapot

--- a/src/test/scala/dpla/ebookapi/v1/endToEnd/PostgresUnauthorizedTest.scala
+++ b/src/test/scala/dpla/ebookapi/v1/endToEnd/PostgresUnauthorizedTest.scala
@@ -6,6 +6,7 @@ import akka.http.scaladsl.model._
 import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import dpla.ebookapi.Routes
+import dpla.ebookapi.helpers.Utils.fakeApiKey
 import dpla.ebookapi.v1.analytics.AnalyticsClient
 import dpla.ebookapi.v1.analytics.AnalyticsClient.AnalyticsClientCommand
 import dpla.ebookapi.v1.authentication.AuthProtocol.AuthenticationCommand
@@ -34,8 +35,6 @@ class PostgresUnauthorizedTest extends AnyWordSpec with Matchers
   val ebookSearch: ActorRef[SearchCommand] =
     MockEbookSearch(testKit, Some(elasticSearchClient), Some(mapper))
 
-  val apiKey = "08e3918eeb8bf4469924f062072459a8"
-
   "/v1/ebooks route" should {
     "return Forbidden if API key not found" in {
       val postgresClient = testKit.spawn(MockPostgresClientKeyNotFound())
@@ -52,7 +51,7 @@ class PostgresUnauthorizedTest extends AnyWordSpec with Matchers
       lazy val routes: Route =
         new Routes(ebookRegistry, apiKeyRegistry).applicationRoutes
 
-      val request = Get(s"/v1/ebooks?api_key=$apiKey")
+      val request = Get(s"/v1/ebooks?api_key=$fakeApiKey")
 
       request ~> Route.seal(routes) ~> check {
         status shouldEqual StatusCodes.Forbidden
@@ -74,7 +73,7 @@ class PostgresUnauthorizedTest extends AnyWordSpec with Matchers
       lazy val routes: Route =
         new Routes(ebookRegistry, apiKeyRegistry).applicationRoutes
 
-      val request = Get(s"/v1/ebooks?api_key=$apiKey")
+      val request = Get(s"/v1/ebooks?api_key=$fakeApiKey")
 
       request ~> Route.seal(routes) ~> check {
         status shouldEqual StatusCodes.Forbidden
@@ -98,7 +97,7 @@ class PostgresUnauthorizedTest extends AnyWordSpec with Matchers
       lazy val routes: Route =
         new Routes(ebookRegistry, apiKeyRegistry).applicationRoutes
 
-      val request = Get(s"/v1/ebooks/R0VfVX4BfY91SSpFGqxt?api_key=$apiKey")
+      val request = Get(s"/v1/ebooks/R0VfVX4BfY91SSpFGqxt?api_key=$fakeApiKey")
 
       request ~> Route.seal(routes) ~> check {
         status shouldEqual StatusCodes.Forbidden
@@ -120,7 +119,7 @@ class PostgresUnauthorizedTest extends AnyWordSpec with Matchers
       lazy val routes: Route =
         new Routes(ebookRegistry, apiKeyRegistry).applicationRoutes
 
-      val request = Get(s"/v1/ebooks/R0VfVX4BfY91SSpFGqxt?api_key=$apiKey")
+      val request = Get(s"/v1/ebooks/R0VfVX4BfY91SSpFGqxt?api_key=$fakeApiKey")
 
       request ~> Route.seal(routes) ~> check {
         status shouldEqual StatusCodes.Forbidden

--- a/src/test/scala/dpla/ebookapi/v1/httpHeadersAndMethods/HeaderAuthorizationTest.scala
+++ b/src/test/scala/dpla/ebookapi/v1/httpHeadersAndMethods/HeaderAuthorizationTest.scala
@@ -7,6 +7,7 @@ import akka.http.scaladsl.model.headers.RawHeader
 import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import dpla.ebookapi.Routes
+import dpla.ebookapi.helpers.Utils.fakeApiKey
 import dpla.ebookapi.v1.analytics.AnalyticsClient
 import dpla.ebookapi.v1.analytics.AnalyticsClient.AnalyticsClientCommand
 import dpla.ebookapi.v1.authentication.AuthProtocol.AuthenticationCommand
@@ -48,12 +49,10 @@ class HeaderAuthorizationTest extends AnyWordSpec with Matchers
   lazy val routes: Route =
     new Routes(ebookRegistry, apiKeyRegistry).applicationRoutes
 
-  val apiKey = "08e3918eeb8bf4469924f062072459a8"
-
   "/v1/ebooks route" should {
     "accept API key in HTTP header" in {
       val request = Get(s"/v1/ebooks")
-        .withHeaders(RawHeader("Authorization", apiKey))
+        .withHeaders(RawHeader("Authorization", fakeApiKey))
 
       request ~> Route.seal(routes) ~> check {
         status shouldEqual StatusCodes.OK
@@ -62,7 +61,7 @@ class HeaderAuthorizationTest extends AnyWordSpec with Matchers
 
     "privilege API key in HTTP header over that in query" in {
       val request = Get(s"/v1/ebooks?api_key=foo")
-        .withHeaders(RawHeader("Authorization", apiKey))
+        .withHeaders(RawHeader("Authorization", fakeApiKey))
 
       request ~> Route.seal(routes) ~> check {
         status shouldEqual StatusCodes.OK
@@ -81,7 +80,7 @@ class HeaderAuthorizationTest extends AnyWordSpec with Matchers
   "/v1/ebooks[id] route" should {
     "accept API key in HTTP header" in {
       val request = Get(s"/v1/ebooks/R0VfVX4BfY91SSpFGqxt")
-        .withHeaders(RawHeader("Authorization", apiKey))
+        .withHeaders(RawHeader("Authorization", fakeApiKey))
 
       request ~> Route.seal(routes) ~> check {
         status shouldEqual StatusCodes.OK
@@ -90,7 +89,7 @@ class HeaderAuthorizationTest extends AnyWordSpec with Matchers
 
     "privilege API key in HTTP header over that in query" in {
       val request = Get(s"/v1/ebooks/R0VfVX4BfY91SSpFGqxt?api_key=foo")
-        .withHeaders(RawHeader("Authorization", apiKey))
+        .withHeaders(RawHeader("Authorization", fakeApiKey))
 
       request ~> Route.seal(routes) ~> check {
         status shouldEqual StatusCodes.OK

--- a/src/test/scala/dpla/ebookapi/v1/httpHeadersAndMethods/PermittedMediaTypesTest.scala
+++ b/src/test/scala/dpla/ebookapi/v1/httpHeadersAndMethods/PermittedMediaTypesTest.scala
@@ -7,6 +7,7 @@ import akka.http.scaladsl.model.headers.Accept
 import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import dpla.ebookapi.Routes
+import dpla.ebookapi.helpers.Utils.fakeApiKey
 import dpla.ebookapi.v1.analytics.AnalyticsClient
 import dpla.ebookapi.v1.analytics.AnalyticsClient.AnalyticsClientCommand
 import dpla.ebookapi.v1.authentication.AuthProtocol.AuthenticationCommand
@@ -48,11 +49,9 @@ class PermittedMediaTypesTest extends AnyWordSpec with Matchers
   lazy val routes: Route =
     new Routes(ebookRegistry, apiKeyRegistry).applicationRoutes
 
-  val apiKey = "08e3918eeb8bf4469924f062072459a8"
-
   "/v1/ebooks route" should {
     "reject invalid media types" in {
-      val request = Get(s"/v1/ebooks?api_key=$apiKey")
+      val request = Get(s"/v1/ebooks?api_key=$fakeApiKey")
         .withHeaders(Accept(Seq(MediaRange(MediaTypes.`application/xml`))))
 
       request ~> Route.seal(routes) ~> check {
@@ -61,7 +60,7 @@ class PermittedMediaTypesTest extends AnyWordSpec with Matchers
     }
 
     "allow valid media type" in {
-      val request = Get(s"/v1/ebooks?api_key=$apiKey")
+      val request = Get(s"/v1/ebooks?api_key=$fakeApiKey")
         .withHeaders(Accept(Seq(MediaRange(MediaTypes.`application/json`))))
 
       request ~> Route.seal(routes) ~> check {
@@ -72,7 +71,7 @@ class PermittedMediaTypesTest extends AnyWordSpec with Matchers
 
   "/v1/ebooks[id] route" should {
     "reject invalid media types" in {
-      val request = Get(s"/v1/ebooks/R0VfVX4BfY91SSpFGqxt?api_key=$apiKey")
+      val request = Get(s"/v1/ebooks/R0VfVX4BfY91SSpFGqxt?api_key=$fakeApiKey")
         .withHeaders(Accept(Seq(MediaRange(MediaTypes.`application/xml`))))
 
       request ~> Route.seal(routes) ~> check {
@@ -81,7 +80,7 @@ class PermittedMediaTypesTest extends AnyWordSpec with Matchers
     }
 
     "allow valid media type" in {
-      val request = Get(s"/v1/ebooks/R0VfVX4BfY91SSpFGqxt?api_key=$apiKey")
+      val request = Get(s"/v1/ebooks/R0VfVX4BfY91SSpFGqxt?api_key=$fakeApiKey")
         .withHeaders(Accept(Seq(MediaRange(MediaTypes.`application/json`))))
 
       request ~> Route.seal(routes) ~> check {

--- a/src/test/scala/dpla/ebookapi/v1/httpHeadersAndMethods/ResponseHeadersTest.scala
+++ b/src/test/scala/dpla/ebookapi/v1/httpHeadersAndMethods/ResponseHeadersTest.scala
@@ -7,6 +7,7 @@ import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import dpla.ebookapi.Routes
 import dpla.ebookapi.helpers.FileReader
+import dpla.ebookapi.helpers.Utils.fakeApiKey
 import dpla.ebookapi.v1.analytics.AnalyticsClient
 import dpla.ebookapi.v1.analytics.AnalyticsClient.AnalyticsClientCommand
 import dpla.ebookapi.v1.authentication.AuthProtocol.AuthenticationCommand
@@ -49,11 +50,9 @@ class ResponseHeadersTest extends AnyWordSpec with Matchers
   lazy val routes: Route =
     new Routes(ebookRegistry, apiKeyRegistry).applicationRoutes
 
-  val apiKey = "08e3918eeb8bf4469924f062072459a8"
-
   "/v1/ebooks response header" should {
     "include correct Content-Type" in {
-      val request = Get(s"/v1/ebooks?api_key=$apiKey")
+      val request = Get(s"/v1/ebooks?api_key=$fakeApiKey")
 
       request ~> Route.seal(routes) ~> check {
         contentType.mediaType shouldEqual MediaTypes.`application/json`
@@ -61,7 +60,7 @@ class ResponseHeadersTest extends AnyWordSpec with Matchers
     }
 
     "include correct Content-Security-Policy" in {
-      val request = Get(s"/v1/ebooks?api_key=$apiKey")
+      val request = Get(s"/v1/ebooks?api_key=$fakeApiKey")
       val expected =
         "default-src 'none'; script-src 'self'; frame-ancestors 'none'; form-action 'self'"
 
@@ -71,7 +70,7 @@ class ResponseHeadersTest extends AnyWordSpec with Matchers
     }
 
     "include correct X-Content-Type-Options" in {
-      val request = Get(s"/v1/ebooks?api_key=$apiKey")
+      val request = Get(s"/v1/ebooks?api_key=$fakeApiKey")
 
       request ~> Route.seal(routes) ~> check {
         header("X-Content-Type-Options").get.value shouldEqual "nosniff"
@@ -79,7 +78,7 @@ class ResponseHeadersTest extends AnyWordSpec with Matchers
     }
 
     "include correct X-Frame-Options" in {
-      val request = Get(s"/v1/ebooks?api_key=$apiKey")
+      val request = Get(s"/v1/ebooks?api_key=$fakeApiKey")
 
       request ~> Route.seal(routes) ~> check {
         header("X-Frame-Options").get.value shouldEqual "DENY"
@@ -89,7 +88,7 @@ class ResponseHeadersTest extends AnyWordSpec with Matchers
 
   "/v1/ebooks[id] response header" should {
     "include correct Content-Type" in {
-      val request = Get(s"/v1/ebooks/R0VfVX4BfY91SSpFGqxt?api_key=$apiKey")
+      val request = Get(s"/v1/ebooks/R0VfVX4BfY91SSpFGqxt?api_key=$fakeApiKey")
 
       request ~> Route.seal(routes) ~> check {
         contentType.mediaType shouldEqual MediaTypes.`application/json`
@@ -97,7 +96,7 @@ class ResponseHeadersTest extends AnyWordSpec with Matchers
     }
 
     "include correct Content-Security-Policy" in {
-      val request = Get(s"/v1/ebooks/R0VfVX4BfY91SSpFGqxt?api_key=$apiKey")
+      val request = Get(s"/v1/ebooks/R0VfVX4BfY91SSpFGqxt?api_key=$fakeApiKey")
       val expected =
         "default-src 'none'; script-src 'self'; frame-ancestors 'none'; form-action 'self'"
 
@@ -107,7 +106,7 @@ class ResponseHeadersTest extends AnyWordSpec with Matchers
     }
 
     "include correct X-Content-Type-Options" in {
-      val request = Get(s"/v1/ebooks/R0VfVX4BfY91SSpFGqxt?api_key=$apiKey")
+      val request = Get(s"/v1/ebooks/R0VfVX4BfY91SSpFGqxt?api_key=$fakeApiKey")
 
       request ~> Route.seal(routes) ~> check {
         header("X-Content-Type-Options").get.value shouldEqual "nosniff"
@@ -115,7 +114,7 @@ class ResponseHeadersTest extends AnyWordSpec with Matchers
     }
 
     "include correct X-Frame-Options" in {
-      val request = Get(s"/v1/ebooks/R0VfVX4BfY91SSpFGqxt?api_key=$apiKey")
+      val request = Get(s"/v1/ebooks/R0VfVX4BfY91SSpFGqxt?api_key=$fakeApiKey")
 
       request ~> Route.seal(routes) ~> check {
         header("X-Frame-Options").get.value shouldEqual "DENY"

--- a/src/test/scala/dpla/ebookapi/v1/registry/EbookRegistryTest.scala
+++ b/src/test/scala/dpla/ebookapi/v1/registry/EbookRegistryTest.scala
@@ -3,6 +3,7 @@ package dpla.ebookapi.v1.registry
 import akka.actor.testkit.typed.scaladsl.{ActorTestKit, TestProbe}
 import akka.actor.typed.ActorRef
 import dpla.ebookapi.helpers.FileReader
+import dpla.ebookapi.helpers.Utils.fakeApiKey
 import dpla.ebookapi.v1.analytics.AnalyticsClient.{AnalyticsClientCommand, TrackFetch, TrackSearch}
 import dpla.ebookapi.v1.authentication.AuthProtocol.AuthenticationCommand
 import dpla.ebookapi.v1.authentication.{MockAuthenticator, MockPostgresClientStaff, MockPostgresClientSuccess}
@@ -43,7 +44,7 @@ class EbookRegistryTest extends AnyWordSpec with Matchers with FileReader
       val ebookRegistry: ActorRef[EbookRegistryCommand] =
         MockEbookRegistry(testKit, authenticator, analyticsProbe.ref, Some(ebookSearch))
 
-      ebookRegistry ! SearchEbooks(Some("08e3918eeb8bf4469924f062072459a8"),
+      ebookRegistry ! SearchEbooks(Some(fakeApiKey),
         Map(), "", "", replyProbe.ref)
 
       analyticsProbe.expectMessageType[TrackSearch]
@@ -58,7 +59,7 @@ class EbookRegistryTest extends AnyWordSpec with Matchers with FileReader
       val ebookRegistry: ActorRef[EbookRegistryCommand] =
         MockEbookRegistry(testKit, authenticator, analyticsProbe.ref, Some(ebookSearch))
 
-      ebookRegistry ! SearchEbooks(Some("08e3918eeb8bf4469924f062072459a8"),
+      ebookRegistry ! SearchEbooks(Some(fakeApiKey),
         Map(), "", "", replyProbe.ref)
 
       analyticsProbe.expectNoMessage
@@ -76,7 +77,7 @@ class EbookRegistryTest extends AnyWordSpec with Matchers with FileReader
       val ebookRegistry: ActorRef[EbookRegistryCommand] =
         MockEbookRegistry(testKit, authenticator, analyticsProbe.ref, Some(ebookSearch))
 
-      ebookRegistry ! FetchEbook(Some("08e3918eeb8bf4469924f062072459a8"),
+      ebookRegistry ! FetchEbook(Some(fakeApiKey),
         "ufwPJ34Bj-MaVWqX9KZL", Map(), "", "", replyProbe.ref)
 
       analyticsProbe.expectMessageType[TrackFetch]
@@ -91,7 +92,7 @@ class EbookRegistryTest extends AnyWordSpec with Matchers with FileReader
       val ebookRegistry: ActorRef[EbookRegistryCommand] =
         MockEbookRegistry(testKit, authenticator, analyticsProbe.ref, Some(ebookSearch))
 
-      ebookRegistry ! FetchEbook(Some("08e3918eeb8bf4469924f062072459a8"),
+      ebookRegistry ! FetchEbook(Some(fakeApiKey),
         "ufwPJ34Bj-MaVWqX9KZL", Map(), "", "", replyProbe.ref)
 
       analyticsProbe.expectNoMessage
@@ -109,7 +110,7 @@ class EbookRegistryTest extends AnyWordSpec with Matchers with FileReader
       val ebookRegistry: ActorRef[EbookRegistryCommand] =
         MockEbookRegistry(testKit, authenticator, analyticsProbe.ref, Some(ebookSearch))
 
-      ebookRegistry ! FetchEbook(Some("08e3918eeb8bf4469924f062072459a8"),
+      ebookRegistry ! FetchEbook(Some(fakeApiKey),
         "b70107e4fe29fe4a247ae46e118ce192,17b0da7b05805d78daf8753a6641b3f5",
         Map(), "", "", replyProbe.ref)
 
@@ -125,7 +126,7 @@ class EbookRegistryTest extends AnyWordSpec with Matchers with FileReader
       val ebookRegistry: ActorRef[EbookRegistryCommand] =
         MockEbookRegistry(testKit, authenticator, analyticsProbe.ref, Some(ebookSearch))
 
-      ebookRegistry ! FetchEbook(Some("08e3918eeb8bf4469924f062072459a8"),
+      ebookRegistry ! FetchEbook(Some(fakeApiKey),
         "b70107e4fe29fe4a247ae46e118ce192,17b0da7b05805d78daf8753a6641b3f5",
         Map(), "", "", replyProbe.ref)
 


### PR DESCRIPTION
I realized I use the fake API key in multiple tests.  This cleans up all of them.