### PR TITLE
run blocking op on fixed thread pool

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -13,11 +13,14 @@ akka {
   }
 }
 dispatchers {
-  blockingDispatcher {
+  emailDispatcher {
     type = Dispatcher
     executor = "thread-pool-executor"
     thread-pool-executor {
-      fixed-pool-size = 8
+      core-pool-size = 2
+      core-pool-size = ${?EMAIL_MIN_THREADS}
+      max-pool-size = 10
+      max-pool-size = ${?EMAIL_MAX_THREADS}
     }
     throughput = 1
   }

--- a/src/main/scala/dpla/ebookapi/v1/email/EmailClient.scala
+++ b/src/main/scala/dpla/ebookapi/v1/email/EmailClient.scala
@@ -77,9 +77,10 @@ object EmailClient {
          // future, which cannot be converted to Scala.
          // Therefore, we're employing a synchronous request that will run on
          // a dedicated dispatcher with a fixed thread pool.
+         // See https://doc.akka.io/docs/akka/current/typed/dispatchers.html#blocking-needs-careful-management
          val blockingExecutionContext: ExecutionContext =
            context.system.dispatchers.lookup(
-             DispatcherSelector.fromConfig("dispatchers.blockingDispatcher")
+             DispatcherSelector.fromConfig("dispatchers.emailDispatcher")
            )
 
          // Create a future response.


### PR DESCRIPTION
Execute blocking operation on a dedicated, fixed thread pool.  This keeps the actor thread pool free to continue normal message processing work while the blocking runs elsewhere.