### PR TITLE
add default api_key route

### DIFF
--- a/src/main/scala/dpla/ebookapi/Routes.scala
+++ b/src/main/scala/dpla/ebookapi/Routes.scala
@@ -66,6 +66,7 @@ class Routes(
   lazy val applicationRoutes: Route =
     concat (
       pathPrefix("ebooks")(ebooksRoutes),
+      pathPrefix("api_key")(apiKeyRoute),
       pathPrefix("v1") {
         concat(
           pathPrefix("ebooks")(ebooksRoutes),


### PR DESCRIPTION
Add a route `/api_key/` equivalent to `/v1/api_key/`