### PR TITLE
Circuit breaker

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -33,14 +33,29 @@ postgres {
 elasticSearch {
   ebooksUrl = "http://localhost:9200/eleanor"
   ebooksUrl = ${?ELASTICSEARCH_URL}
+  circuitBreaker {
+    timeout = 3s
+    failures = 3
+    reset = 20s
+  }
 }
 awsSes {
   emailFrom  = "info@dp.la"
   emailFrom = ${?EMAIL_FROM}
   region = "us-east-1"
   region = ${?AWS_REGION}
+  circuitBreaker {
+    timeout = 3s
+    failures = 3
+    reset = 20s
+  }
 }
 googleAnalytics {
   trackingId = "UA-XXXXXXXX-X"
   trackingId = ${?GOOGLE_ANALYTICS_ID}
+  circuitBreaker {
+    timeout = 3s
+    failures = 3
+    reset = 20s
+  }
 }

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -44,18 +44,8 @@ awsSes {
   emailFrom = ${?EMAIL_FROM}
   region = "us-east-1"
   region = ${?AWS_REGION}
-  circuitBreaker {
-    timeout = 3s
-    failures = 3
-    reset = 20s
-  }
 }
 googleAnalytics {
   trackingId = "UA-XXXXXXXX-X"
   trackingId = ${?GOOGLE_ANALYTICS_ID}
-  circuitBreaker {
-    timeout = 3s
-    failures = 3
-    reset = 20s
-  }
 }

--- a/src/main/scala/dpla/ebookapi/v1/search/ElasticSearchResponseHandler.scala
+++ b/src/main/scala/dpla/ebookapi/v1/search/ElasticSearchResponseHandler.scala
@@ -54,7 +54,7 @@ object ElasticSearchResponseHandler {
     Behaviors.setup { context =>
 
       // Set up circuit breaker.
-      // If calls to ElasticSearch takes [timeout] seconds to complete
+      // If calls to ElasticSearch take at least [timeout] seconds to complete
       // [failures] number of times, assume ElasticSearch is struggling and
       // don't attempt any more calls for [reset] seconds.
       // While waiting for reset, requests to this actor will quickly return

--- a/src/main/scala/dpla/ebookapi/v1/search/ElasticSearchResponseHandler.scala
+++ b/src/main/scala/dpla/ebookapi/v1/search/ElasticSearchResponseHandler.scala
@@ -8,7 +8,7 @@ import akka.http.scaladsl.model.HttpMessage.DiscardedEntity
 import akka.http.scaladsl.unmarshalling.Unmarshaller
 import akka.pattern.CircuitBreaker
 
-import scala.concurrent.duration.{DurationInt, FiniteDuration}
+import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.{ExecutionContextExecutor, Future}
 import scala.util.{Failure, Success}
 import scala.jdk.DurationConverters._
@@ -54,10 +54,11 @@ object ElasticSearchResponseHandler {
     Behaviors.setup { context =>
 
       // Set up circuit breaker.
-      // If call to external service takes [timeout] seconds to complete
-      // [failures] number of times in a row, don't attempt any more external
-      // call for [reset] seconds.
-      // While waiting for reset, requests to this actor will fail fast.
+      // If calls to ElasticSearch takes [timeout] seconds to complete
+      // [failures] number of times, assume ElasticSearch is struggling and
+      // don't attempt any more calls for [reset] seconds.
+      // While waiting for reset, requests to this actor will quickly return
+      // an ElasticSearchResponseFailure message.
 
       val failures: Int = context.system.settings.config
         .getInt("elasticSearch.circuitBreaker.failures")

--- a/src/main/scala/dpla/ebookapi/v1/search/ElasticSearchResponseHandler.scala
+++ b/src/main/scala/dpla/ebookapi/v1/search/ElasticSearchResponseHandler.scala
@@ -58,7 +58,7 @@ object ElasticSearchResponseHandler {
       // [failures] number of times in a row, don't attempt any more external
       // call for [reset] seconds.
       // While waiting for reset, requests to this actor will fail fast.
-      
+
       val failures: Int = context.system.settings.config
         .getInt("elasticSearch.circuitBreaker.failures")
 
@@ -83,6 +83,7 @@ object ElasticSearchResponseHandler {
 
         case ProcessElasticSearchResponse(futureHttpResponse, replyTo) =>
           // Map the Future value to a message, handled by this actor.
+          // Use circuit breaker.
           context.pipeToSelf(breaker.withCircuitBreaker(futureHttpResponse)) {
             case Success(httpResponse) =>
               ProcessHttpResponse(httpResponse, replyTo)


### PR DESCRIPTION
This introduces the circuit breaker pattern for calls to ElasticSearch.  It it intended to offer a modicum of protection to ElasticSearch by detecting when the service is struggling to respond in a timely manner and stopping calls for a short period to give it time to recover.  This can be especially helpful if the source of ElasticSearch's problems is calls coming from this application.  Let me know if this seems like an appropriate safety measure to use here.