### PR TITLE
analytics tracking without api keys

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -43,4 +43,6 @@ awsSes {
 googleAnalytics {
   trackingId = "UA-XXXXXXXX-X"
   trackingId = ${?GOOGLE_ANALYTICS_ID}
+  clientId = "dev-client-id"
+  clientId = ${?GOOGLE_ANALYTICS_CLIENT}
 }

--- a/src/main/scala/dpla/ebookapi/v1/registry/EbookRegistryBehavior.scala
+++ b/src/main/scala/dpla/ebookapi/v1/registry/EbookRegistryBehavior.scala
@@ -107,14 +107,9 @@ trait EbookRegistryBehavior {
               case Some(ebookList) =>
                 // ...and if account is not staff/internal...
                 if (!account.staff.getOrElse(false) && !account.email.endsWith("@dp.la")) {
-                  apiKey match {
-                    case Some(key) =>
-                      // ...track analytics hit
-                      analyticsClient ! TrackSearch(key, rawParams, host, path,
-                        ebookList.docs)
-                    case None =>
-                    // no-op (this should not happen)
-                  }
+                  // ...track analytics hit
+                  analyticsClient ! TrackSearch(rawParams, host, path,
+                    ebookList.docs)
                 }
               case None => // no-op
             }
@@ -220,20 +215,14 @@ trait EbookRegistryBehavior {
               case Some(either) =>
                 // ...and if account is not staff/internal...
                 if (!account.staff.getOrElse(false) && !account.email.endsWith("@dp.la")) {
-                  apiKey match {
-                    case Some(key) =>
-                      // ...track analytics hit.
-                      either match {
-                        case Left(singleEbook) =>
-                          analyticsClient ! TrackFetch(key, host, path,
-                            singleEbook.docs.headOption)
-                        case Right(ebookList) =>
-                          analyticsClient ! TrackSearch(key, rawParams, host,
-                            path, ebookList.docs)
-                      }
-
-                    case None =>
-                    // no-op (this should not happen)
+                  // ...track analytics hit.
+                  either match {
+                    case Left(singleEbook) =>
+                      analyticsClient ! TrackFetch(host, path,
+                        singleEbook.docs.headOption)
+                    case Right(ebookList) =>
+                      analyticsClient ! TrackSearch(rawParams, host, path,
+                        ebookList.docs)
                   }
                 }
               case None => // no-op


### PR DESCRIPTION
For Google analytics tracking, do not differentiate between users with different API keys.  Instead, track all API use as coming from the same client.  