### PR TITLE
handle empty param and unused DPLA MAP facets

### DIFF
--- a/src/main/scala/dpla/ebookapi/Routes.scala
+++ b/src/main/scala/dpla/ebookapi/Routes.scala
@@ -42,7 +42,7 @@ class Routes(
     val apiKey: Option[String] =
       if (auth.nonEmpty) auth
       else params.get("api_key")
-    val updatedParams = params.filterNot(_._1 == "api_key")
+    val updatedParams = params.filterNot(_._1 == "api_key").filterNot(_._2.trim.isEmpty)
     ebookRegistry.ask(SearchEbooks(apiKey, updatedParams, host, path, _))
   }
 
@@ -56,7 +56,7 @@ class Routes(
     val apiKey: Option[String] =
       if (auth.nonEmpty) auth
       else params.get("api_key")
-    val updatedParams = params.filterNot(_._1 == "api_key")
+    val updatedParams = params.filterNot(_._1 == "api_key").filterNot(_._2.trim.isEmpty)
     ebookRegistry.ask(FetchEbook(apiKey, id, updatedParams, host, path, _))
   }
 

--- a/src/test/scala/dpla/ebookapi/v1/endToEnd/InvalidParamsTest.scala
+++ b/src/test/scala/dpla/ebookapi/v1/endToEnd/InvalidParamsTest.scala
@@ -55,6 +55,14 @@ class InvalidParamsTest extends AnyWordSpec with Matchers
         status shouldEqual StatusCodes.BadRequest
       }
     }
+
+    "ignore empty params" in {
+      val request = Get(s"/v1/ebooks?page=&api_key=$fakeApiKey")
+
+      request ~> Route.seal(routes) ~> check {
+        status should not be StatusCodes.BadRequest
+      }
+    }
   }
 
   "/v1/ebooks[id] route" should {

--- a/src/test/scala/dpla/ebookapi/v1/search/EbookParamValidatorTest.scala
+++ b/src/test/scala/dpla/ebookapi/v1/search/EbookParamValidatorTest.scala
@@ -265,6 +265,15 @@ class EbookParamValidatorTest extends AnyWordSpec with Matchers
       paramValidator ! RawSearchParams(params, replyProbe.ref)
       replyProbe.expectMessageType[InvalidSearchParams]
     }
+
+    "ignore valid DPLA Map fields not applicable to ebooks" in {
+      val given = "rightsCategory"
+      val expected = Some(Seq())
+      val params = Map("facets" -> given)
+      paramValidator ! RawSearchParams(params, replyProbe.ref)
+      val msg = interProbe.expectMessageType[ValidSearchParams]
+      msg.params.facets shouldEqual expected
+    }
   }
 
   "facet size validator" should {


### PR DESCRIPTION
Michael, this should unblock you on the frontend.  There is probably a better / more comprehensive way of handling unused DPLA MAP field than the hardcoded list, but it will be easier to implement once the CH API is supported in this application.  I'll make a ticket to circle back to this during the "migrate CH API to akka" epic.