### PR TITLE
fix nested json arrays of objects

### DIFF
--- a/src/main/scala/dpla/ebookapi/v1/search/JsonFormats.scala
+++ b/src/main/scala/dpla/ebookapi/v1/search/JsonFormats.scala
@@ -43,18 +43,18 @@ object JsonFormats extends DefaultJsonProtocol with JsonFieldReader {
         )),
         "sourceResource" -> filterIfEmpty(JsObject(
           "creator" -> ebook.author.toJson,
-          "date" -> filterIfEmpty(JsObject(
-            "displayDate" -> ebook.publicationDate.toJson
-          )),
+          "date" -> ebook.publicationDate.map(displayDate =>
+            JsObject("displayDate" -> displayDate.toJson)
+          ).toJson,
           "description" -> ebook.summary.toJson,
           "format" -> ebook.medium.toJson,
-          "language" -> filterIfEmpty(JsObject(
-            "name" -> ebook.language.toJson,
-          )),
+          "language" -> ebook.language.map(name =>
+            JsObject("name" -> name.toJson)
+          ).toJson,
           "publisher" -> ebook.publisher.toJson,
-          "subject" -> filterIfEmpty(JsObject(
-            "name" -> ebook.genre.toJson
-          )),
+          "subject" -> ebook.genre.map(name =>
+            JsObject("name" -> name.toJson)
+          ).toJson,
           "subtitle" -> ebook.subtitle.toJson,
           "title" -> ebook.title.toJson
         ))

--- a/src/test/scala/dpla/ebookapi/v1/search/SingleEbookMappingTest.scala
+++ b/src/test/scala/dpla/ebookapi/v1/search/SingleEbookMappingTest.scala
@@ -44,8 +44,9 @@ class SingleEbookMappingTest extends AnyWordSpec with Matchers
         "Lawyers -- Fiction",
         "London (England) -- Social life and customs -- 20th century -- Fiction"
       )
-      val traversed =
-        readStringArray(firstDoc, "sourceResource", "subject", "name")
+      val subjects =
+        readObjectArray(firstDoc, "sourceResource", "subject")
+      val traversed = subjects.flatMap(s => readString(s, "name"))
       traversed should contain allElementsOf expected
     }
 
@@ -66,8 +67,9 @@ class SingleEbookMappingTest extends AnyWordSpec with Matchers
 
     "map language" in {
       val expected = "en-GB"
-      val traversed =
-        readStringArray(firstDoc, "sourceResource", "language", "name")
+      val languages =
+        readObjectArray(firstDoc, "sourceResource", "language")
+      val traversed = languages.flatMap(s => readString(s, "name"))
       traversed should contain only expected
     }
 
@@ -99,8 +101,9 @@ class SingleEbookMappingTest extends AnyWordSpec with Matchers
 
     "map publicationDate" in {
       val expected = "1922"
-      val traversed =
-        readStringArray(firstDoc, "sourceResource", "date", "displayDate")
+      val dates =
+        readObjectArray(firstDoc, "sourceResource", "date")
+      val traversed = dates.flatMap(s => readString(s, "displayDate"))
       traversed should contain only expected
     }
 


### PR DESCRIPTION
This fixes the JSON output for three `sourceResource` fields.
Before, they were objects with array values, when they should be arrays of objects.

E.g. before:
```
"language": {
  "name": ["english", "french"]
}
```

After:
```
"language": [
  { "name":  "english" },
  { "name": "french" }
]
```