### PR TITLE
multiple filters for pss about.name

### DIFF
--- a/src/main/scala/dpla/api/v2/search/models/PssFields.scala
+++ b/src/main/scala/dpla/api/v2/search/models/PssFields.scala
@@ -75,6 +75,15 @@ trait PssFields extends FieldDefinitions {
       elasticSearchNotAnalyzed = None
     ),
     DataField(
+      name = "about.name",
+      fieldType = TextField,
+      searchable = true,
+      facetable = false,
+      sortable = false,
+      elasticSearchDefault = "about.name",
+      elasticSearchNotAnalyzed = Some("about.name")
+    ),
+    DataField(
       name = "about.sameAs",
       fieldType = TextField,
       searchable = false,

--- a/src/main/scala/dpla/api/v2/search/paramValidators/PssParamValidator.scala
+++ b/src/main/scala/dpla/api/v2/search/paramValidators/PssParamValidator.scala
@@ -6,7 +6,7 @@ object PssParamValidator extends ParamValidator with PssFields {
 
   // These parameters are valid for a search request.
   override protected val acceptedSearchParams: Seq[String] =
-    searchableDataFields ++ Seq("fields", "sort_by", "sort_order")
+    searchableDataFields ++ Seq("fields", "filter", "sort_by", "sort_order")
 
   // These parameters are valid for a fetch request.
   override protected val acceptedFetchParams: Seq[String] = Seq()

--- a/src/main/scala/dpla/api/v2/search/queryBuilders/QueryBuilder.scala
+++ b/src/main/scala/dpla/api/v2/search/queryBuilders/QueryBuilder.scala
@@ -130,7 +130,7 @@ trait QueryBuilder extends FieldDefinitions with DefaultJsonProtocol {
   private def from(page: Int, pageSize: Int): Int = (page - 1) * pageSize
 
   private def query(q: Option[String],
-                    filter: Option[Filter],
+                    filter: Option[Seq[Filter]],
                     fieldQueries: Seq[FieldQuery],
                     exactFieldMatch: Boolean,
                     op: String
@@ -184,16 +184,21 @@ trait QueryBuilder extends FieldDefinitions with DefaultJsonProtocol {
    * This will filter out fields that do not match the given value, but will
    * not affect the score for matching documents.
    */
-  private def filterQuery(filter: Filter): JsObject =
-    JsObject(
-      "bool" -> JsObject(
-        "must" -> JsObject(
-          "term" -> JsObject(
-            filter.fieldName -> filter.value.toJson
-          )
+  private def filterQuery(filters: Seq[Filter]): JsObject = {
+    val mustArray: JsValue = filters.map(filter => {
+      JsObject(
+        "term" -> JsObject(
+          filter.fieldName -> filter.value.toJson
         )
       )
+    }).toJson
+
+    JsObject(
+      "bool" -> JsObject(
+        "must" -> mustArray
+      )
     )
+  }
 
   /**
    * For general field query, use a keyword (i.e. "query_string") query.

--- a/src/test/scala/dpla/api/v2/search/paramValidators/ParamValidatorTest.scala
+++ b/src/test/scala/dpla/api/v2/search/paramValidators/ParamValidatorTest.scala
@@ -842,28 +842,28 @@ class ParamValidatorTest extends AnyWordSpec with Matchers
   "filter validator" should {
     "accept valid value for URL field" in {
       val given = "provider.@id:http://dp.la/api/contributor/lc"
-      val expectedFieldName = Some("provider.@id")
-      val expectedValue = Some("http://dp.la/api/contributor/lc")
+      val expectedFieldName = "provider.@id"
+      val expectedValue = "http://dp.la/api/contributor/lc"
       val params = Map("filter" -> given)
       itemParamValidator ! RawSearchParams(params, replyProbe.ref)
       val msg = interProbe.expectMessageType[ValidSearchParams]
-      val fieldName = msg.params.filter.map(_.fieldName)
-      val value = msg.params.filter.map(_.value)
-      assert(fieldName == expectedFieldName)
-      assert(value == expectedValue)
+      val fieldName = msg.params.filter.flatMap(_.headOption.map(_.fieldName))
+      val value = msg.params.filter.flatMap(_.headOption.map(_.value))
+      fieldName should contain (expectedFieldName)
+      value should contain (expectedValue)
     }
 
     "accept valid value for text field" in {
       val given = "provider.name:california"
-      val expectedFieldName = Some("provider.name")
-      val expectedValue = Some("california")
+      val expectedFieldName = "provider.name"
+      val expectedValue = "california"
       val params = Map("filter" -> given)
       itemParamValidator ! RawSearchParams(params, replyProbe.ref)
       val msg = interProbe.expectMessageType[ValidSearchParams]
-      val fieldName = msg.params.filter.map(_.fieldName)
-      val value = msg.params.filter.map(_.value)
-      assert(fieldName == expectedFieldName)
-      assert(value == expectedValue)
+      val fieldName = msg.params.filter.flatMap(_.headOption.map(_.fieldName))
+      val value = msg.params.filter.flatMap(_.headOption.map(_.value))
+      fieldName should contain (expectedFieldName)
+      value should contain (expectedValue)
     }
 
     "reject unsearchable field" in {

--- a/src/test/scala/dpla/api/v2/search/queryBuilders/QueryBuilderTest.scala
+++ b/src/test/scala/dpla/api/v2/search/queryBuilders/QueryBuilderTest.scala
@@ -146,7 +146,7 @@ class QueryBuilderTest extends AnyWordSpec with Matchers
     facetSize = 100,
     fields = None,
     fieldQueries = Seq[FieldQuery](),
-    filter = Some(Filter("provider.@id", "http://dp.la/api/contributor/lc")),
+    filter = Some(Seq(Filter("provider.@id", "http://dp.la/api/contributor/lc"))),
     op = "AND",
     page = 3,
     pageSize = 20,
@@ -166,7 +166,7 @@ class QueryBuilderTest extends AnyWordSpec with Matchers
   val multiFetchQuery: JsObject = getJsFetchQuery(multiFetchIds)
 
   val randomParams: RandomParams = RandomParams(
-    filter = Some(Filter("provider.@id", "http://dp.la/api/contributor/lc")),
+    filter = Some(Seq(Filter("provider.@id", "http://dp.la/api/contributor/lc"))),
   )
 
   val randomQuery: JsObject = getJsRandomQuery(randomParams)
@@ -233,8 +233,9 @@ class QueryBuilderTest extends AnyWordSpec with Matchers
 
     "specify filter" in {
       val expected = Some("http://dp.la/api/contributor/lc")
-      val traversed = readString(randomQuery, "query", "function_score",
-        "query", "bool", "filter", "bool", "must", "term", "provider.@id")
+      val traversed = readObjectArray(randomQuery, "query", "function_score",
+        "query", "bool", "filter", "bool", "must").headOption
+        .flatMap(must => readString(must, "term", "provider.@id"))
       assert(traversed == expected)
     }
   }
@@ -778,8 +779,10 @@ class QueryBuilderTest extends AnyWordSpec with Matchers
   "filter query builder" should {
     "specify field and term" in {
       val expected = Some("http://dp.la/api/contributor/lc")
-      val traversed = readString(filterQuery, "query", "bool", "filter",
-        "bool", "must", "term", "provider.@id")
+      val traversed =
+        readObjectArray(filterQuery, "query", "bool", "filter", "bool", "must")
+          .headOption
+          .flatMap(must => readString(must, "term", "provider.@id"))
       assert(traversed == expected)
     }
   }


### PR DESCRIPTION
This enables a feature akin to tag filtering for primary source sets.
This uses a `filter` on the `about.name` field.  An example query looks like: 
`filter=about.name:Expansion and Reform (1801-1861)+AND+Migration`
The API already had the ability to do filter queries, but was only supporting one filter term per field.  This updates it to allow multiple filter terms per field.