### PR TITLE
Limit related sets

### DIFF
--- a/src/it/scala/dpla/api/v2/search/PssTests.scala
+++ b/src/it/scala/dpla/api/v2/search/PssTests.scala
@@ -208,6 +208,16 @@ class PssTests extends ITHelper with LogCapturing with FileReader {
         traversed should not be empty
       }
     }
+
+    "have a limited number of related sets" in {
+      request ~> routes ~> check {
+        val entity: JsObject = entityAs[String].parseJson.asJsObject
+
+        val traversed: Seq[JsValue] = readObjectArray(entity, "isRelatedTo")
+
+        assert(traversed.length == 8)
+      }
+    }
   }
 
   "each set endpoint" should {

--- a/src/main/scala/dpla/api/v2/search/mappings/PssJsonFormats.scala
+++ b/src/main/scala/dpla/api/v2/search/mappings/PssJsonFormats.scala
@@ -116,7 +116,7 @@ object PssJsonFormats extends JsonFieldReader
         "educationalAlignment" -> pssSet.educationalAlignment.toJson,
         "hasPart" -> pssSet.hasPart.toJson,
         "inLanguage" -> pssSet.inLanguage.toJson,
-        "isRelatedTo" -> pssSet.isRelatedTo.toJson,
+        "isRelatedTo" -> pssSet.isRelatedTo.take(8).toJson, // limit related sets
         "learningResourceType" -> pssSet.learningResourceType.toJson,
         "license" -> pssSet.license.toJson,
         "name" -> pssSet.name.toJson,


### PR DESCRIPTION
If we want to limit the number of related sets so that the JSON isn't so bloated, we could to this.