### PR TITLE
match source ids on full uris

### DIFF
--- a/src/main/scala/dpla/api/v2/search/mappings/PssMapper.scala
+++ b/src/main/scala/dpla/api/v2/search/mappings/PssMapper.scala
@@ -88,7 +88,7 @@ object PssMapper extends Mapper {
           mappedSet.map(set => {
             set.hasPart.filter(part =>
               part.disambiguatingDescription.contains("source") &&
-                part.`@id`.getOrElse("").endsWith("/" + sourceId.getOrElse(""))
+                part.`@id`.getOrElse("") == sourceId.getOrElse("").stripSuffix("\"").stripPrefix("\"")
             ).head.copy(`@context` = set.`@context`, disambiguatingDescription = None)
           })
         else mappedSetList

--- a/src/main/scala/dpla/api/v2/search/models/PssFields.scala
+++ b/src/main/scala/dpla/api/v2/search/models/PssFields.scala
@@ -220,7 +220,7 @@ trait PssFields extends FieldDefinitions {
     ),
     DataField(
       name = "hasPart.id",
-      fieldType = IntField,
+      fieldType = URLField,
       searchable = true,
       facetable = false,
       sortable = false,

--- a/src/test/scala/dpla/api/v2/search/paramValidators/PssParamValidatorTest.scala
+++ b/src/test/scala/dpla/api/v2/search/paramValidators/PssParamValidatorTest.scala
@@ -60,8 +60,8 @@ class PssParamValidatorTest extends AnyWordSpec with Matchers
   }
 
   "hasPart.id validator" should {
-    "accept an integer" in {
-      val expected = "7"
+    "construct an ES-safe URI from an Int" in {
+      val expected = "\"https://api.dp.la/primary-source-sets/sources/7\""
       val params = Map("hasPart.id" -> "7")
       pssParamValidator ! RawSearchParams(params, replyProbe.ref)
       val msg = interProbe.expectMessageType[ValidSearchParams]
@@ -70,7 +70,7 @@ class PssParamValidatorTest extends AnyWordSpec with Matchers
       id should contain(expected)
     }
 
-    "reject a non-integer" in {
+    "reject an invalid URI" in {
       val params = Map("hasPart.id" -> "foo")
       pssParamValidator ! RawSearchParams(params, replyProbe.ref)
       replyProbe.expectMessageType[InvalidSearchParams]


### PR DESCRIPTION
When searching elasticsearch for source IDs, this matches on the full URL.  Before, it was matching the ID a the end of the URL, so the request for source 1930 was matching both the source _and_ the teaching guide whose ID is `immigration-and-americanization-1880-1930`.  This has been tested locally.