### PR TITLE
Added container healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,6 @@ WORKDIR /opt/api
 COPY sentry.properties .
 COPY sentry-opentelemetry-agent.jar .
 COPY target/scala-2.13/dpla-api.jar .
-HEALTHCHECK CMD ["curl", "-f", "http://localhost:8080/health-check"]
+HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 CMD ["curl", "-f", "http://localhost:8080/health-check"]
 EXPOSE 8080
 CMD ["java", "-javaagent:sentry-opentelemetry-agent.jar", "-jar", "/opt/api/dpla-api.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,5 +10,6 @@ WORKDIR /opt/api
 COPY sentry.properties .
 COPY sentry-opentelemetry-agent.jar .
 COPY target/scala-2.13/dpla-api.jar .
+HEALTHCHECK CMD ["curl", "-f", "http://localhost:8080/health-check"]
 EXPOSE 8080
 CMD ["java", "-javaagent:sentry-opentelemetry-agent.jar", "-jar", "/opt/api/dpla-api.jar"]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add health check to Dockerfile to monitor container health via HTTP request.
> 
>   - **Dockerfile**:
>     - Added `HEALTHCHECK` instruction to monitor container health by checking `http://localhost:8080/health-check` every 30 seconds, with a timeout of 10 seconds, a start period of 5 seconds, and 3 retries.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dpla%2Fapi&utm_source=github&utm_medium=referral)<sup> for c6581960acb3f6656e0d6697bde39b83b4eac19d. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->