### PR TITLE
made it so you can turn off psql cert validation locally

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -40,8 +40,11 @@ postgres {
     password = "devpassword"
     password = ${?POSTGRES_PASSWORD}
     ssl = true
+    ssl = ${?SSL}
     sslmode = "verify-full"
+    sslmode = ${?SSL_MODE}
     sslfactory = "org.postgresql.ssl.DefaultJavaSSLFactory"
+    sslfactory = ${?SSL_FACTORY}
   }
   numThreads = 10
   numThreads = ${?POSTGRES_THREADS}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enable local override of PostgreSQL SSL settings in `application.conf` using environment variables.
> 
>   - **Configuration**:
>     - In `application.conf`, PostgreSQL SSL settings can now be overridden by environment variables `SSL`, `SSL_MODE`, and `SSL_FACTORY`.
>     - Allows disabling SSL certificate validation locally by setting these environment variables.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dpla%2Fapi&utm_source=github&utm_medium=referral)<sup> for 300792f6f889e9a106182c6b74674a6117c4712f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->