### PR TITLE
Added java arg for consuming more RAM.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,4 @@ COPY sentry-opentelemetry-agent.jar .
 COPY target/scala-2.13/dpla-api.jar .
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 CMD ["curl", "-f", "http://localhost:8080/health-check"]
 EXPOSE 8080
-CMD ["java", "-javaagent:sentry-opentelemetry-agent.jar", "-jar", "/opt/api/dpla-api.jar"]
+CMD ["java", "-XX:MaxRAMPercentage=85", "-javaagent:sentry-opentelemetry-agent.jar", "-jar", "/opt/api/dpla-api.jar"]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Added `-XX:MaxRAMPercentage=85` to Java command in Dockerfile to allow Java to use up to 85% of available RAM.
> 
>   - **Dockerfile**:
>     - Added `-XX:MaxRAMPercentage=85` to the Java command in `CMD` to allow Java to use up to 85% of available RAM.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dpla%2Fapi&utm_source=github&utm_medium=referral)<sup> for 9d1b89e177250287c57b46bb279195e6b80d722e. You can [customize](https://app.ellipsis.dev/dpla/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->