### PR TITLE
chore: add deploy-api-services script

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -17,7 +17,13 @@ When deploying both the DPLA API and the thumbnail API in the same maintenance w
 ~/bin/deploy-api-services thumb    # thumbnail-api only
 ```
 
-`deploy-api-services` is a local operator script at `~/bin/deploy-api-services` on the deploy machine — it is not part of this repository. It handles pre-flight checks, parallel ECR builds, ECR verification, and parallel pipeline execution with live monitoring. If you don't have it, follow the manual steps below for each service separately.
+`deploy-api-services` lives at `bin/deploy-api-services` in this repository. Copy it to `~/bin/` on the deploy machine:
+
+```bash
+cp bin/deploy-api-services ~/bin/ && chmod +x ~/bin/deploy-api-services
+```
+
+It handles pre-flight health checks, deployed-vs-main comparison, in-flight pipeline detection, parallel ECR builds, ECR verification, and parallel pipeline execution with live monitoring. If you don't have it, follow the manual steps below for each service separately.
 
 ---
 

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -12,9 +12,10 @@ The DPLA API is a Scala/JVM service running on AWS ECS Fargate (8 tasks, blue/gr
 When deploying both the DPLA API and the thumbnail API in the same maintenance window, use the combined script to run everything in parallel. This produces one impact window instead of two:
 
 ```bash
-~/bin/deploy-api-services          # deploy both
-~/bin/deploy-api-services api      # api only
-~/bin/deploy-api-services thumb    # thumbnail-api only
+~/bin/deploy-api-services           # deploy both
+~/bin/deploy-api-services api       # api only
+~/bin/deploy-api-services thumb     # thumbnail-api only
+~/bin/deploy-api-services preflight # pre-flight checks only — no builds or deploys
 ```
 
 `deploy-api-services` lives at `bin/deploy-api-services` in this repository. Copy it to `~/bin/` on the deploy machine:

--- a/bin/deploy-api-services
+++ b/bin/deploy-api-services
@@ -248,13 +248,13 @@ for pipeline_check in \
   [[ "$enabled" != "true" ]] && continue
   if ! in_flight=$($AWS codepipeline list-pipeline-executions \
     --pipeline-name "$pipeline" --region "$REGION" \
-    --query 'pipelineExecutionSummaries[?status==`InProgress`].pipelineExecutionId' \
+    --query 'pipelineExecutionSummaries[?status==`InProgress` || status==`Stopping`].pipelineExecutionId' \
     --output json 2>/dev/null | jq 'length'); then
     err "Failed to check in-flight status for $pipeline — aborting"
     exit 1
   fi
   if [[ "$in_flight" -gt 0 ]]; then
-    err "$pipeline already has an execution in progress — aborting"
+    err "$pipeline already has an execution in progress or stopping — aborting"
     exit 1
   fi
 done

--- a/bin/deploy-api-services
+++ b/bin/deploy-api-services
@@ -14,8 +14,8 @@
 
 set -euo pipefail
 
-AWS=/usr/local/aws-cli/aws
-GH=/opt/homebrew/bin/gh
+AWS=${AWS:-$(command -v aws 2>/dev/null || true)}
+GH=${GH:-$(command -v gh 2>/dev/null || true)}
 REGION=us-east-1
 
 # ── helpers ────────────────────────────────────────────────────────────────
@@ -24,10 +24,23 @@ log()  { echo "[$(date '+%H:%M:%S')] $*"; }
 err()  { echo "[$(date '+%H:%M:%S')] ERROR: $*" >&2; }
 bold() { printf '\033[1m%s\033[0m\n' "$*"; }
 
+[[ -n "$AWS" && -x "$AWS" ]] || { err "aws CLI not found in PATH (set \$AWS or add aws to PATH)"; exit 1; }
+[[ -n "$GH"  && -x "$GH"  ]] || { err "gh CLI not found in PATH (set \$GH or add gh to PATH)";   exit 1; }
+
+abort_if_build_in_flight() {
+  local repo=$1 workflow=$2 service=$3
+  local count
+  count=$($GH run list --repo "$repo" --workflow "$workflow" \
+    --json status \
+    --jq '[.[] | select(.status == "in_progress" or .status == "queued" or .status == "waiting" or .status == "requested" or .status == "pending")] | length' \
+    2>/dev/null || echo 0)
+  [[ "$count" -gt 0 ]] && { err "$service ECR build already in progress — aborting to avoid :latest tag race"; exit 1; }
+}
+
 wait_for_gh_run() {
   local repo=$1 workflow_name=$2 triggered_after=$3
   local run_id=""
-  log "Waiting for $workflow_name to appear in $repo..."
+  log "Waiting for $workflow_name to appear in $repo..." >&2
   for i in $(seq 1 20); do
     run_id=$($GH run list --repo "$repo" --workflow "$workflow_name" \
       --json databaseId,createdAt,status \
@@ -86,8 +99,17 @@ verify_ecr_image() {
     err "Could not read ECR image for $repo"
     return 1
   fi
-  if [[ "$pushed" < "$triggered_after" ]]; then
-    err "$repo ECR image ($pushed) predates trigger time ($triggered_after) — build may have failed"
+  # ECR returns imagePushedAt as a Unix epoch float; TRIGGER_TIME is RFC3339.
+  # Convert both to integer epoch seconds before comparing.
+  local pushed_epoch triggered_epoch
+  pushed_epoch=${pushed%%.*}
+  triggered_epoch=$(python3 -c "
+import datetime
+dt = datetime.datetime.strptime('$triggered_after', '%Y-%m-%dT%H:%M:%SZ').replace(tzinfo=datetime.timezone.utc)
+print(int(dt.timestamp()))
+")
+  if (( pushed_epoch < triggered_epoch )); then
+    err "$repo ECR image (epoch $pushed) predates trigger time ($triggered_after) — build may have failed"
     return 1
   fi
   log "$repo ECR image pushed at $pushed — OK"
@@ -95,7 +117,7 @@ verify_ecr_image() {
 
 start_pipeline() {
   local name=$1
-  log "Starting CodePipeline: $name"
+  log "Starting CodePipeline: $name" >&2
   $AWS codepipeline start-pipeline-execution --name "$name" --region "$REGION" \
     --query 'pipelineExecutionId' --output text
 }
@@ -145,8 +167,8 @@ show_deploy_summary() {
     --jq '.sha[0:7] + " — " + (.commit.message | split("\n")[0]) + " (" + (.commit.committer.date | split("T")[0]) + ")"' \
     2>/dev/null || echo "(unknown)")
   echo "  $label:"
-  echo "    📦 ECR image last pushed: $ecr_pushed"
-  echo "    🔜 Will deploy:           $main_commit"
+  echo "    📦 ECR :latest tag pushed: $ecr_pushed"
+  echo "    🔜 Will deploy:            $main_commit"
 }
 
 # ── service definitions ────────────────────────────────────────────────────
@@ -202,6 +224,10 @@ bold "=== What will be deployed ==="
 [[ "$DEPLOY_API" == "true" ]]   && show_deploy_summary "api"           api           dpla/api
 [[ "$DEPLOY_THUMB" == "true" ]] && show_deploy_summary "thumbnail-api" thumbnail-api dpla/thumbnail-api
 echo
+
+# Check for in-flight GH Actions ECR builds — a running build can overwrite :latest
+[[ "$DEPLOY_API"   == "true" ]] && abort_if_build_in_flight dpla/api           "Deploy to Amazon ECR"       api
+[[ "$DEPLOY_THUMB" == "true" ]] && abort_if_build_in_flight dpla/thumbnail-api  "push to ecr: production"    thumbnail-api
 
 # Check for in-flight pipelines
 for pipeline_check in \

--- a/bin/deploy-api-services
+++ b/bin/deploy-api-services
@@ -8,6 +8,7 @@
 #   deploy-api-services           # deploy both api and thumbnail-api
 #   deploy-api-services api       # deploy only the DPLA API
 #   deploy-api-services thumb     # deploy only the thumbnail API
+#   deploy-api-services preflight # run pre-flight checks only — no builds or deploys
 #
 # Canonical source: dpla/api bin/deploy-api-services
 # Copy to ~/bin/ on the deploy machine: cp bin/deploy-api-services ~/bin/
@@ -167,17 +168,44 @@ poll_pipeline() {
 show_deploy_summary() {
   local label=$1 ecr_repo=$2 gh_repo=$3
   local ecr_pushed main_commit
-  ecr_pushed=$($AWS ecr describe-images \
+
+  # Fetch both fields in one call; jq extracts each with a safe fallback.
+  local ecr_image ecr_pushed ecr_digest
+  ecr_image=$($AWS ecr describe-images \
     --repository-name "$ecr_repo" \
-    --image-ids imageTag=latest \
-    --region "$REGION" \
-    --query 'imageDetails[0].imagePushedAt' \
-    --output text 2>/dev/null || echo "(unknown)")
+    --image-ids imageTag=latest --region "$REGION" \
+    --query 'imageDetails[0]' --output json 2>/dev/null || echo '{}')
+  ecr_pushed=$(echo "$ecr_image" | jq -r '.imagePushedAt // "(unknown)"')
+  ecr_digest=$(echo "$ecr_image"  | jq -r '.imageDigest  // ""')
+
   main_commit=$($GH api "repos/$gh_repo/commits/main" \
     --jq '.sha[0:7] + " — " + (.commit.message | split("\n")[0]) + " (" + (.commit.committer.date | split("T")[0]) + ")"' \
     2>/dev/null || echo "(unknown)")
+
+  # Compare the digest of the running container to ECR :latest to detect a stale deploy.
+  # Cluster and service names match ecr_repo in our infrastructure.
+  local task_arn="" running_digest="" deployed_note=""
+  task_arn=$($AWS ecs list-tasks \
+    --cluster "$ecr_repo" --service-name "$ecr_repo" \
+    --desired-status RUNNING --region "$REGION" \
+    --query 'taskArns[0]' --output text 2>/dev/null || echo "")
+  if [[ -n "$task_arn" && "$task_arn" != "None" ]]; then
+    running_digest=$($AWS ecs describe-tasks \
+      --cluster "$ecr_repo" --tasks "$task_arn" --region "$REGION" \
+      --query 'tasks[0].containers[0].imageDigest' --output text 2>/dev/null || echo "")
+  fi
+  if [[ -z "$running_digest" || "$running_digest" == "None" ]]; then
+    deployed_note="(unknown — could not read running container)"
+  elif [[ "$running_digest" == "$ecr_digest" ]]; then
+    deployed_note="✅ up to date (matches ECR :latest)"
+  else
+    # :7 skips the "sha256:" prefix; show 12 hex chars from each digest for a quick visual diff
+    deployed_note="⚠️  stale (running ${running_digest:7:12}… / ECR :latest ${ecr_digest:7:12}…)"
+  fi
+
   echo "  $label:"
-  echo "    📦 ECR :latest tag pushed: $ecr_pushed"
+  echo "    🟢 Deployed image:         $deployed_note"
+  echo "    📦 ECR :latest pushed:     $ecr_pushed"
   echo "    🔜 Will deploy:            $main_commit"
 }
 
@@ -186,12 +214,15 @@ show_deploy_summary() {
 DEPLOY_API=false
 DEPLOY_THUMB=false
 
+PRE_FLIGHT_ONLY=false
+
 case "${1:-both}" in
-  both)   DEPLOY_API=true; DEPLOY_THUMB=true ;;
-  api)    DEPLOY_API=true ;;
-  thumb)  DEPLOY_THUMB=true ;;
+  both)      DEPLOY_API=true; DEPLOY_THUMB=true ;;
+  api)       DEPLOY_API=true ;;
+  thumb)     DEPLOY_THUMB=true ;;
+  preflight) DEPLOY_API=true; DEPLOY_THUMB=true; PRE_FLIGHT_ONLY=true ;;
   *)
-    echo "Usage: $0 [both|api|thumb]"
+    echo "Usage: $0 [both|api|thumb|preflight]"
     exit 1
     ;;
 esac
@@ -259,6 +290,11 @@ for pipeline_check in \
   fi
 done
 log "Pre-flight checks passed"
+
+if [[ "$PRE_FLIGHT_ONLY" == "true" ]]; then
+  log "Pre-flight-only mode — exiting without building or deploying."
+  exit 0
+fi
 echo
 
 # ── phase 1: trigger ECR builds ────────────────────────────────────────────

--- a/bin/deploy-api-services
+++ b/bin/deploy-api-services
@@ -34,10 +34,13 @@ done
 abort_if_build_in_flight() {
   local repo=$1 workflow=$2 service=$3
   local count
-  count=$($GH run list --repo "$repo" --workflow "$workflow" \
+  if ! count=$($GH run list --repo "$repo" --workflow "$workflow" \
     --json status \
     --jq '[.[] | select(.status == "in_progress" or .status == "queued" or .status == "waiting" or .status == "requested" or .status == "pending")] | length' \
-    2>/dev/null || echo 0)
+    2>&1); then
+    err "Failed to check in-flight builds for $service — aborting"
+    exit 1
+  fi
   [[ "$count" -gt 0 ]] && { err "$service ECR build already in progress — aborting to avoid :latest tag race"; exit 1; }
 }
 

--- a/bin/deploy-api-services
+++ b/bin/deploy-api-services
@@ -246,10 +246,13 @@ for pipeline_check in \
   enabled=${pipeline_check%%:*}
   pipeline=${pipeline_check##*:}
   [[ "$enabled" != "true" ]] && continue
-  in_flight=$($AWS codepipeline list-pipeline-executions \
+  if ! in_flight=$($AWS codepipeline list-pipeline-executions \
     --pipeline-name "$pipeline" --region "$REGION" \
     --query 'pipelineExecutionSummaries[?status==`InProgress`].pipelineExecutionId' \
-    --output json | jq 'length')
+    --output json 2>/dev/null | jq 'length'); then
+    err "Failed to check in-flight status for $pipeline — aborting"
+    exit 1
+  fi
   if [[ "$in_flight" -gt 0 ]]; then
     err "$pipeline already has an execution in progress — aborting"
     exit 1

--- a/bin/deploy-api-services
+++ b/bin/deploy-api-services
@@ -1,0 +1,349 @@
+#!/usr/bin/env bash
+# deploy-api-services — build and deploy api + thumbnail-api in one pass
+#
+# Runs both ECR builds in parallel, waits for both, then starts both
+# CodePipelines simultaneously. One maintenance window, not two.
+#
+# Usage:
+#   deploy-api-services           # deploy both api and thumbnail-api
+#   deploy-api-services api       # deploy only the DPLA API
+#   deploy-api-services thumb     # deploy only the thumbnail API
+#
+# Canonical source: dpla/api bin/deploy-api-services
+# Copy to ~/bin/ on the deploy machine: cp bin/deploy-api-services ~/bin/
+
+set -euo pipefail
+
+AWS=/usr/local/aws-cli/aws
+GH=/opt/homebrew/bin/gh
+REGION=us-east-1
+
+# ── helpers ────────────────────────────────────────────────────────────────
+
+log()  { echo "[$(date '+%H:%M:%S')] $*"; }
+err()  { echo "[$(date '+%H:%M:%S')] ERROR: $*" >&2; }
+bold() { printf '\033[1m%s\033[0m\n' "$*"; }
+
+wait_for_gh_run() {
+  local repo=$1 workflow_name=$2 triggered_after=$3
+  local run_id=""
+  log "Waiting for $workflow_name to appear in $repo..."
+  for i in $(seq 1 20); do
+    run_id=$($GH run list --repo "$repo" --workflow "$workflow_name" \
+      --json databaseId,createdAt,status \
+      --jq "[.[] | select(.createdAt >= \"$triggered_after\")][0].databaseId" 2>/dev/null || true)
+    [[ -n "$run_id" && "$run_id" != "null" ]] && break
+    sleep 10
+  done
+  if [[ -z "$run_id" || "$run_id" == "null" ]]; then
+    err "Could not find $workflow_name run for $repo triggered after $triggered_after"
+    return 1
+  fi
+  echo "$run_id"
+}
+
+poll_gh_run() {
+  local repo=$1 run_id=$2 label=$3
+  log "Watching $label (run $run_id)..."
+  while true; do
+    local run_json status conclusion
+    run_json=$($GH run view "$run_id" --repo "$repo" --json status,conclusion 2>/dev/null || echo '{}')
+    status=$(echo "$run_json" | jq -r '.status // "unknown"')
+    conclusion=$(echo "$run_json" | jq -r '.conclusion // ""')
+    case "$status" in
+      completed)
+        if [[ "$conclusion" == "success" ]]; then
+          log "$label: completed successfully"
+          return 0
+        else
+          err "$label: finished with conclusion '$conclusion'"
+          return 1
+        fi
+        ;;
+      in_progress|queued|waiting|requested|pending)
+        log "$label: $status..."
+        sleep 30
+        ;;
+      *)
+        err "$label: unexpected status '$status'"
+        return 1
+        ;;
+    esac
+  done
+}
+
+verify_ecr_image() {
+  local repo=$1 triggered_after=$2
+  log "Verifying $repo ECR image..."
+  local pushed
+  pushed=$($AWS ecr describe-images \
+    --repository-name "$repo" \
+    --image-ids imageTag=latest \
+    --region "$REGION" \
+    --query 'imageDetails[0].imagePushedAt' \
+    --output text 2>/dev/null || echo "")
+  if [[ -z "$pushed" ]]; then
+    err "Could not read ECR image for $repo"
+    return 1
+  fi
+  if [[ "$pushed" < "$triggered_after" ]]; then
+    err "$repo ECR image ($pushed) predates trigger time ($triggered_after) — build may have failed"
+    return 1
+  fi
+  log "$repo ECR image pushed at $pushed — OK"
+}
+
+start_pipeline() {
+  local name=$1
+  log "Starting CodePipeline: $name"
+  $AWS codepipeline start-pipeline-execution --name "$name" --region "$REGION" \
+    --query 'pipelineExecutionId' --output text
+}
+
+poll_pipeline() {
+  local name=$1 exec_id=$2
+  log "Monitoring $name ($exec_id)..."
+  while true; do
+    local status
+    status=$($AWS codepipeline get-pipeline-execution \
+      --pipeline-name "$name" \
+      --pipeline-execution-id "$exec_id" \
+      --region "$REGION" \
+      --query 'pipelineExecution.status' \
+      --output text 2>/dev/null || echo "Unknown")
+    case "$status" in
+      Succeeded)
+        log "$name: Succeeded"
+        return 0
+        ;;
+      Failed|Cancelled|Stopped|Superseded)
+        err "$name: $status — check the console"
+        return 1
+        ;;
+      InProgress|Stopping)
+        log "$name: $status..."
+        sleep 30
+        ;;
+      *)
+        log "$name: status=$status, waiting..."
+        sleep 30
+        ;;
+    esac
+  done
+}
+
+show_deploy_summary() {
+  local label=$1 ecr_repo=$2 gh_repo=$3
+  local ecr_pushed main_commit
+  ecr_pushed=$($AWS ecr describe-images \
+    --repository-name "$ecr_repo" \
+    --image-ids imageTag=latest \
+    --region "$REGION" \
+    --query 'imageDetails[0].imagePushedAt' \
+    --output text 2>/dev/null || echo "(unknown)")
+  main_commit=$($GH api "repos/$gh_repo/commits/main" \
+    --jq '.sha[0:7] + " — " + (.commit.message | split("\n")[0]) + " (" + (.commit.committer.date | split("T")[0]) + ")"' \
+    2>/dev/null || echo "(unknown)")
+  echo "  $label:"
+  echo "    📦 ECR image last pushed: $ecr_pushed"
+  echo "    🔜 Will deploy:           $main_commit"
+}
+
+# ── service definitions ────────────────────────────────────────────────────
+
+DEPLOY_API=false
+DEPLOY_THUMB=false
+
+case "${1:-both}" in
+  both)   DEPLOY_API=true; DEPLOY_THUMB=true ;;
+  api)    DEPLOY_API=true ;;
+  thumb)  DEPLOY_THUMB=true ;;
+  *)
+    echo "Usage: $0 [both|api|thumb]"
+    exit 1
+    ;;
+esac
+
+# Load secrets for health checks (non-fatal if absent)
+source ~/.claude/secrets/dpla.env 2>/dev/null || true
+
+# ── pre-flight ──────────────────────────────────────────────────────────────
+
+bold "=== DPLA API Services Deploy ==="
+log "Services: $( [[ $DEPLOY_API == true ]] && echo 'api ' )$( [[ $DEPLOY_THUMB == true ]] && echo 'thumbnail-api' )"
+echo
+
+bold "=== Pre-flight checks ==="
+
+# Service health checks — do not deploy to a broken service
+if [[ "$DEPLOY_API" == "true" ]]; then
+  API_HEALTH=$(curl -o /dev/null -s -w "%{http_code}" \
+    "https://api.dp.la/v2/items?api_key=${DPLA_API_KEY:-test}&page_size=1" 2>/dev/null || echo "000")
+  if [[ "$API_HEALTH" != "200" ]]; then
+    err "api.dp.la is unhealthy (HTTP $API_HEALTH) — do not deploy to a broken service"
+    exit 1
+  fi
+  log "api.dp.la: HTTP $API_HEALTH — healthy"
+fi
+
+if [[ "$DEPLOY_THUMB" == "true" ]]; then
+  # Use dp.la/thumb/... routing — thumb.dp.la may 403 from CloudFront WAF on this machine
+  THUMB_HEALTH=$(curl -o /dev/null -s -w "%{http_code}" \
+    "https://dp.la/thumb/ee7d7c513000727d22613e1c6ba17061" 2>/dev/null || echo "000")
+  if [[ "$THUMB_HEALTH" != "200" && "$THUMB_HEALTH" != "202" && "$THUMB_HEALTH" != "302" ]]; then
+    err "thumbnail API is unhealthy (HTTP $THUMB_HEALTH) — do not deploy to a broken service"
+    exit 1
+  fi
+  log "thumbnail API: HTTP $THUMB_HEALTH — healthy"
+fi
+
+echo
+bold "=== What will be deployed ==="
+[[ "$DEPLOY_API" == "true" ]]   && show_deploy_summary "api"           api           dpla/api
+[[ "$DEPLOY_THUMB" == "true" ]] && show_deploy_summary "thumbnail-api" thumbnail-api dpla/thumbnail-api
+echo
+
+# Check for in-flight pipelines
+for pipeline_check in \
+  "$DEPLOY_API:api-pipeline" \
+  "$DEPLOY_THUMB:thumbnail-api-pipeline"; do
+  enabled=${pipeline_check%%:*}
+  pipeline=${pipeline_check##*:}
+  [[ "$enabled" != "true" ]] && continue
+  in_flight=$($AWS codepipeline list-pipeline-executions \
+    --pipeline-name "$pipeline" --region "$REGION" \
+    --query 'pipelineExecutionSummaries[?status==`InProgress`].pipelineExecutionId' \
+    --output json | jq 'length')
+  if [[ "$in_flight" -gt 0 ]]; then
+    err "$pipeline already has an execution in progress — aborting"
+    exit 1
+  fi
+done
+log "Pre-flight checks passed"
+echo
+
+# ── phase 1: trigger ECR builds ────────────────────────────────────────────
+
+bold "=== Phase 1: Building Docker images ==="
+TRIGGER_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+if [[ "$DEPLOY_API" == "true" ]]; then
+  log "Dispatching api ECR build (sbt assembly + Docker, ~20-25 min)..."
+  $GH api --method POST /repos/dpla/api/actions/workflows/deploy.yml/dispatches \
+    -f ref=main > /dev/null
+fi
+
+if [[ "$DEPLOY_THUMB" == "true" ]]; then
+  log "Dispatching thumbnail-api ECR build (~5-10 min)..."
+  $GH api --method POST /repos/dpla/thumbnail-api/actions/workflows/ecr.yml/dispatches \
+    -f ref=main > /dev/null
+fi
+
+sleep 5  # brief pause for GitHub to register the runs
+
+# Collect run IDs
+API_RUN_ID=""
+THUMB_RUN_ID=""
+
+if [[ "$DEPLOY_API" == "true" ]]; then
+  API_RUN_ID=$(wait_for_gh_run dpla/api "Deploy to Amazon ECR" "$TRIGGER_TIME")
+  log "api GH run ID: $API_RUN_ID"
+fi
+
+if [[ "$DEPLOY_THUMB" == "true" ]]; then
+  THUMB_RUN_ID=$(wait_for_gh_run dpla/thumbnail-api "push to ecr: production" "$TRIGGER_TIME")
+  log "thumbnail-api GH run ID: $THUMB_RUN_ID"
+fi
+
+echo
+
+# ── phase 2: wait for builds (parallel) ────────────────────────────────────
+
+bold "=== Phase 2: Waiting for builds ==="
+FAILED=0
+
+# Run both polls in background, capture exit codes
+API_POLL_PID=""
+THUMB_POLL_PID=""
+
+if [[ "$DEPLOY_API" == "true" ]]; then
+  poll_gh_run dpla/api "$API_RUN_ID" "api ECR build" &
+  API_POLL_PID=$!
+fi
+
+if [[ "$DEPLOY_THUMB" == "true" ]]; then
+  poll_gh_run dpla/thumbnail-api "$THUMB_RUN_ID" "thumbnail-api ECR build" &
+  THUMB_POLL_PID=$!
+fi
+
+[[ -n "$API_POLL_PID" ]]   && { wait $API_POLL_PID   || FAILED=1; }
+[[ -n "$THUMB_POLL_PID" ]] && { wait $THUMB_POLL_PID || FAILED=1; }
+
+if [[ "$FAILED" -eq 1 ]]; then
+  err "One or more ECR builds failed — aborting before pipeline start"
+  exit 1
+fi
+
+echo
+
+# ── phase 3: verify ECR images ─────────────────────────────────────────────
+
+bold "=== Phase 3: Verifying ECR images ==="
+[[ "$DEPLOY_API" == "true" ]]   && verify_ecr_image api           "$TRIGGER_TIME"
+[[ "$DEPLOY_THUMB" == "true" ]] && verify_ecr_image thumbnail-api "$TRIGGER_TIME"
+echo
+
+# ── phase 4: start pipelines simultaneously ────────────────────────────────
+
+bold "=== Phase 4: Starting CodePipelines ==="
+API_EXEC_ID=""
+THUMB_EXEC_ID=""
+
+[[ "$DEPLOY_API" == "true" ]]   && API_EXEC_ID=$(start_pipeline api-pipeline)
+[[ "$DEPLOY_THUMB" == "true" ]] && THUMB_EXEC_ID=$(start_pipeline thumbnail-api-pipeline)
+echo
+
+# ── phase 5: monitor pipelines (parallel) ──────────────────────────────────
+
+bold "=== Phase 5: Monitoring deployments ==="
+FAILED=0
+
+API_PIPE_PID=""
+THUMB_PIPE_PID=""
+
+if [[ "$DEPLOY_API" == "true" ]]; then
+  poll_pipeline api-pipeline "$API_EXEC_ID" &
+  API_PIPE_PID=$!
+fi
+
+if [[ "$DEPLOY_THUMB" == "true" ]]; then
+  poll_pipeline thumbnail-api-pipeline "$THUMB_EXEC_ID" &
+  THUMB_PIPE_PID=$!
+fi
+
+[[ -n "$API_PIPE_PID" ]]   && { wait $API_PIPE_PID   || FAILED=1; }
+[[ -n "$THUMB_PIPE_PID" ]] && { wait $THUMB_PIPE_PID || FAILED=1; }
+
+echo
+
+# ── done ───────────────────────────────────────────────────────────────────
+
+if [[ "$FAILED" -eq 1 ]]; then
+  err "One or more deployments failed — check the AWS CodePipeline console"
+  exit 1
+fi
+
+bold "=== All deployments succeeded ==="
+if [[ "$DEPLOY_API" == "true" ]]; then
+  log "api health check:"
+  curl -sf "https://api.dp.la/v2/items?api_key=${DPLA_API_KEY:-test}&page_size=1" \
+    | python3 -c "import sys,json; d=json.load(sys.stdin); print('  api.dp.la: HTTP 200 —', d['count'], 'items')" \
+    || log "  (health check request failed — verify manually)"
+fi
+if [[ "$DEPLOY_THUMB" == "true" ]]; then
+  log "thumbnail-api health check:"
+  # Use dp.la/thumb/... routing — thumb.dp.la may 403 from CloudFront WAF on this machine
+  curl -sf -o /dev/null -w "  thumbnail API: HTTP %{http_code}\n" \
+    "https://dp.la/thumb/ee7d7c513000727d22613e1c6ba17061" \
+    || log "  (health check request failed — verify manually)"
+fi

--- a/bin/deploy-api-services
+++ b/bin/deploy-api-services
@@ -27,6 +27,10 @@ bold() { printf '\033[1m%s\033[0m\n' "$*"; }
 [[ -n "$AWS" && -x "$AWS" ]] || { err "aws CLI not found in PATH (set \$AWS or add aws to PATH)"; exit 1; }
 [[ -n "$GH"  && -x "$GH"  ]] || { err "gh CLI not found in PATH (set \$GH or add gh to PATH)";   exit 1; }
 
+for cmd in jq curl python3; do
+  command -v "$cmd" >/dev/null 2>&1 || { err "$cmd not found in PATH"; exit 1; }
+done
+
 abort_if_build_in_flight() {
   local repo=$1 workflow=$2 service=$3
   local count
@@ -127,12 +131,15 @@ poll_pipeline() {
   log "Monitoring $name ($exec_id)..."
   while true; do
     local status
-    status=$($AWS codepipeline get-pipeline-execution \
+    if ! status=$($AWS codepipeline get-pipeline-execution \
       --pipeline-name "$name" \
       --pipeline-execution-id "$exec_id" \
       --region "$REGION" \
       --query 'pipelineExecution.status' \
-      --output text 2>/dev/null || echo "Unknown")
+      --output text 2>/dev/null); then
+      err "$name: could not read pipeline execution status"
+      return 1
+    fi
     case "$status" in
       Succeeded)
         log "$name: Succeeded"
@@ -147,8 +154,8 @@ poll_pipeline() {
         sleep 30
         ;;
       *)
-        log "$name: status=$status, waiting..."
-        sleep 30
+        err "$name: unexpected status '$status'"
+        return 1
         ;;
     esac
   done

--- a/bin/deploy-api-services
+++ b/bin/deploy-api-services
@@ -369,17 +369,27 @@ if [[ "$FAILED" -eq 1 ]]; then
   exit 1
 fi
 
-bold "=== All deployments succeeded ==="
+POST_DEPLOY_FAILED=0
 if [[ "$DEPLOY_API" == "true" ]]; then
   log "api health check:"
-  curl -sf "https://api.dp.la/v2/items?api_key=${DPLA_API_KEY:-test}&page_size=1" \
-    | python3 -c "import sys,json; d=json.load(sys.stdin); print('  api.dp.la: HTTP 200 —', d['count'], 'items')" \
-    || log "  (health check request failed — verify manually)"
+  if ! curl -sf "https://api.dp.la/v2/items?api_key=${DPLA_API_KEY:-test}&page_size=1" \
+    | python3 -c "import sys,json; d=json.load(sys.stdin); print('  api.dp.la: HTTP 200 —', d['count'], 'items')"; then
+    err "api post-deploy health check failed"
+    POST_DEPLOY_FAILED=1
+  fi
 fi
 if [[ "$DEPLOY_THUMB" == "true" ]]; then
   log "thumbnail-api health check:"
   # Use dp.la/thumb/... routing — thumb.dp.la may 403 from CloudFront WAF on this machine
-  curl -sf -o /dev/null -w "  thumbnail API: HTTP %{http_code}\n" \
-    "https://dp.la/thumb/ee7d7c513000727d22613e1c6ba17061" \
-    || log "  (health check request failed — verify manually)"
+  if ! curl -sf -o /dev/null -w "  thumbnail API: HTTP %{http_code}\n" \
+    "https://dp.la/thumb/ee7d7c513000727d22613e1c6ba17061"; then
+    err "thumbnail-api post-deploy health check failed"
+    POST_DEPLOY_FAILED=1
+  fi
 fi
+
+if [[ "$POST_DEPLOY_FAILED" -eq 1 ]]; then
+  exit 1
+fi
+
+bold "=== All deployments succeeded ==="


### PR DESCRIPTION
## Summary

- Adds `bin/deploy-api-services` — the combined deploy script for api + thumbnail-api, previously operator-local only
- Script now lives in the repo so it can be found, versioned, and copied to new deploy machines
- Updates `DEPLOY.md` to reference the repo path (`cp bin/deploy-api-services ~/bin/`) instead of "it lives somewhere on the operator's machine"

## Script improvements over the prior local copy

- **Pre-deploy health check**: aborts if the service is already broken before triggering any builds
- **Deployed-vs-main comparison**: shows what ECR image is live vs. what `main` will deploy, before builds start
- **Thumbnail health check URL**: uses `dp.la/thumb/...` routing — `thumb.dp.la` may 403 from CloudFront WAF on the operator machine
- **Single `gh run view` call per poll iteration** (was two separate calls per loop)
- **`jq` instead of `python3`** for pipeline in-flight count

## Test plan

- [ ] Script is executable: `ls -l bin/deploy-api-services`
- [ ] Copy to ~/bin/ and verify it runs: `~/bin/deploy-api-services --help` (should print usage)
- [ ] Dry-run pre-flight only: check health check and deployed-vs-main output without triggering a build

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR adds a repository-hosted deployment helper script and updates deployment documentation.

### Changes
- Adds bin/deploy-api-services (executable Bash script) and updates DEPLOY.md to document copying the script to ~/bin/ and its usage.
- Script features / behavior:
  - CLI: supports both|api|thumb|preflight (default: both). preflight runs health checks only and exits before triggering builds.
  - Validates required CLIs (aws, gh, jq, curl, python3) and uses strict error handling (set -euo pipefail).
  - Pre-deploy HTTP health checks (thumbnail check uses dp.la/thumb/... routing to avoid thumb.dp.la CloudFront WAF 403s).
  - Shows deployed-vs-main comparison by fetching the running ECS task image digest/timestamp and comparing with ECR :latest before builds.
  - Detects in-flight GitHub Actions runs and AWS CodePipeline executions and aborts to avoid :latest tag races; added "Stopping" to the preflight JMESPath filter so cancellations block deploys.
  - Uses jq (instead of python3) to count in-flight pipelines and reduces GH API calls (single gh run view per poll iteration).
  - Dispatches GitHub Actions workflow_dispatch events, polls runs in parallel, and fails fast on non-successful builds.
  - Verifies ECR :latest image push timestamp is at/after the recorded trigger time.
  - Starts AWS CodePipelines concurrently and polls until terminal states; fails on pipeline or AWS API errors.
  - Performs post-deploy HTTP health checks and now exits non-zero on failures (previously logged but exited 0).
  - Optionally sources operator-local secrets from ~/.claude/secrets/dpla.env for health checks; DPLA_API_KEY defaults to literal "test" if unset.

- DEPLOY.md updates:
  - Documents the repository location (bin/deploy-api-services), install step (cp + chmod), preflight usage, and explicitly notes merging to main does not auto-deploy (pipeline webhook disabled).

### Commits / fixes
- Adds preflight-only mode and deployed-vs-ECR comparison.
- Collapses duplicate ECR describe-images calls.
- Adds explicit error guard around pipeline in-flight check and includes "Stopping" in preflight filter.
- Adjusts post-deploy behavior to fail the script on health-check errors.

### Security & Operational Notes (explicit)
- Manual trigger required: Deploys are initiated by running the script (it dispatches GitHub Actions and starts CodePipeline). Merging to main does not auto-deploy.
- Environment / secrets: No environment variables or AWS Secrets Manager keys are added, removed, or renamed. The script may read an operator-local secrets file (~/.claude/secrets/dpla.env); operators should secure that file. If unset, DPLA_API_KEY defaults to the literal "test".
- Database migrations: None.
- Shared infrastructure/configuration: No repository changes to CodePipeline/CodeBuild/ECS task definitions/IAM policies. The script invokes existing workflows and pipelines but does not modify their definitions.
- Public API: No changes to API response shapes or endpoints.
- Security implications: The script performs production HTTP requests and can read operator-local secrets—ensure deploy-machine filesystem protections and restrict access to operator accounts. Stricter failure behavior (post-deploy checks, pipeline/AWS error surfacing) reduces the chance of silent, failed deploys.

### Testing / Usage notes
- Verify executable and usage: ls -l bin/deploy-api-services; copy to ~/bin/ and run --help.
- Use preflight mode to exercise health checks and deployed-vs-main output without triggering builds or pipeline executions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->