### PR TITLE
fix: warn on partial ES results (timed_out, failed shards, truncated facets)

### DIFF
--- a/src/main/scala/dpla/api/v2/search/mappings/DPLAMAPJsonFormats.scala
+++ b/src/main/scala/dpla/api/v2/search/mappings/DPLAMAPJsonFormats.scala
@@ -2,6 +2,7 @@ package dpla.api.v2.search.mappings
 
 import dpla.api.v2.search.mappings.JsonFormatsHelper._
 import dpla.api.v2.search.models.DPLAMAPFields
+import org.slf4j.LoggerFactory
 import spray.json._
 
 /**
@@ -10,6 +11,8 @@ import spray.json._
  */
 object DPLAMAPJsonFormats extends JsonFieldReader
   with DPLAMAPFields {
+
+  private val log = LoggerFactory.getLogger(getClass)
 
   implicit object BucketFormat extends RootJsonFormat[Bucket] {
 
@@ -79,6 +82,14 @@ object DPLAMAPJsonFormats extends JsonFieldReader
                 readObjectArray(root, fieldName, "buckets")
               }
 
+            // Warn when ES truncated a terms aggregation (more buckets exist than returned)
+            if (`type` == "terms" && log.isWarnEnabled) {
+              readInt(root, fieldName, "sum_other_doc_count").foreach { n =>
+                if (n > 0)
+                  log.warn(s"ES terms aggregation '$fieldName' truncated: $n additional docs not in response")
+              }
+            }
+
             Facet(
               field = fieldName,
               `type` = `type`,
@@ -136,6 +147,15 @@ object DPLAMAPJsonFormats extends JsonFieldReader
 
     def read(json: JsValue): DPLADocList = {
       val root = json.asJsObject
+
+      // Warn on partial results — partial results are silently returned otherwise
+      if (log.isWarnEnabled) {
+        if (readBoolean(root, "timed_out").contains(true))
+          log.warn("ES query timed out — results may be partial")
+        readInt(root, "_shards", "failed").foreach { n =>
+          if (n > 0) log.warn(s"ES query had $n failed shard(s) — results may be partial")
+        }
+      }
 
       DPLADocList(
         count = readInt(root, "hits", "total", "value"),

--- a/src/main/scala/dpla/api/v2/search/mappings/PssJsonFormats.scala
+++ b/src/main/scala/dpla/api/v2/search/mappings/PssJsonFormats.scala
@@ -2,6 +2,7 @@ package dpla.api.v2.search.mappings
 
 import dpla.api.v2.search.mappings.JsonFormatsHelper.filterIfEmpty
 import dpla.api.v2.search.models.PssFields
+import org.slf4j.LoggerFactory
 import spray.json._
 
 /**
@@ -10,6 +11,8 @@ import spray.json._
  */
 object PssJsonFormats extends JsonFieldReader
   with PssFields {
+
+  private val log = LoggerFactory.getLogger(getClass)
 
   implicit object PssSourceFormat extends RootJsonFormat[PssPart] {
     def read(json: JsValue): PssPart = {
@@ -136,6 +139,15 @@ object PssJsonFormats extends JsonFieldReader
 
     def read(json: JsValue): PssSetList = {
       val root = json.asJsObject
+
+      // Warn on partial results — partial results are silently returned otherwise
+      if (log.isWarnEnabled) {
+        if (readBoolean(root, "timed_out").contains(true))
+          log.warn("ES query timed out — PSS results may be partial")
+        readInt(root, "_shards", "failed").foreach { n =>
+          if (n > 0) log.warn(s"ES query had $n failed shard(s) — PSS results may be partial")
+        }
+      }
 
       PssSetList(
         `@context` = readObjectArray(root, "hits", "hits").headOption.map { hit =>


### PR DESCRIPTION
## Summary

Silent partial results from ElasticSearch were being returned to callers with no indication that the data was incomplete. This adds WARN-level logging for three conditions:

- **`timed_out: true`** — query took too long and ES returned whatever it had; logged in both `DPLADocListFormat` and `PssSetListFormat`
- **`_shards.failed > 0`** — one or more shards couldn't be reached; logged in both formats
- **`sum_other_doc_count > 0`** on terms aggregations — ES truncated the facet buckets to `facetSize`; logged per-field in `FacetListFormat`

All checks are guarded with `log.isWarnEnabled` to avoid eager string interpolation when the WARN log level is disabled.

## Test plan

- [ ] Normal search: no new log output
- [ ] Mock an ES response with `timed_out: true` — verify `"ES query timed out"` appears in logs
- [ ] Mock an ES response with `_shards.failed: 1` — verify shard failure warning appears
- [ ] Mock a terms aggregation with `sum_other_doc_count: 5` — verify truncation warning appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced internal logging to detect and warn when search results may be incomplete due to query timeouts, truncated facets, or shard failures, improving observability of potential data quality issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->