### PR TITLE
fix: add browser User-Agent to thumbnail health check curl calls

### DIFF
--- a/bin/deploy-api-services
+++ b/bin/deploy-api-services
@@ -18,6 +18,7 @@ set -euo pipefail
 AWS=${AWS:-$(command -v aws 2>/dev/null || true)}
 GH=${GH:-$(command -v gh 2>/dev/null || true)}
 REGION=us-east-1
+BROWSER_UA="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36"
 
 # ── helpers ────────────────────────────────────────────────────────────────
 
@@ -250,8 +251,9 @@ if [[ "$DEPLOY_API" == "true" ]]; then
 fi
 
 if [[ "$DEPLOY_THUMB" == "true" ]]; then
-  # Use dp.la/thumb/... routing — thumb.dp.la may 403 from CloudFront WAF on this machine
+  # Use dp.la/thumb/... routing — pass a browser UA (CloudFront WAF blocks curl's default User-Agent)
   THUMB_HEALTH=$(curl -o /dev/null -s -w "%{http_code}" \
+    -A "$BROWSER_UA" \
     "https://dp.la/thumb/ee7d7c513000727d22613e1c6ba17061" 2>/dev/null || echo "000")
   if [[ "$THUMB_HEALTH" != "200" && "$THUMB_HEALTH" != "202" && "$THUMB_HEALTH" != "302" ]]; then
     err "thumbnail API is unhealthy (HTTP $THUMB_HEALTH) — do not deploy to a broken service"
@@ -419,8 +421,9 @@ if [[ "$DEPLOY_API" == "true" ]]; then
 fi
 if [[ "$DEPLOY_THUMB" == "true" ]]; then
   log "thumbnail-api health check:"
-  # Use dp.la/thumb/... routing — thumb.dp.la may 403 from CloudFront WAF on this machine
+  # Use dp.la/thumb/... routing — pass a browser UA (CloudFront WAF blocks curl's default User-Agent)
   if ! curl -sf -o /dev/null -w "  thumbnail API: HTTP %{http_code}\n" \
+    -A "$BROWSER_UA" \
     "https://dp.la/thumb/ee7d7c513000727d22613e1c6ba17061"; then
     err "thumbnail-api post-deploy health check failed"
     POST_DEPLOY_FAILED=1

--- a/bin/deploy-api-services
+++ b/bin/deploy-api-services
@@ -18,7 +18,7 @@ set -euo pipefail
 AWS=${AWS:-$(command -v aws 2>/dev/null || true)}
 GH=${GH:-$(command -v gh 2>/dev/null || true)}
 REGION=us-east-1
-BROWSER_UA="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36"
+BROWSER_UA=${BROWSER_UA:-"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36"}
 
 # ── helpers ────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- Both pre-flight and post-deploy health checks that hit `https://dp.la/thumb/ee7d7c513000727d22613e1c6ba17061` were missing a `User-Agent` header
- CloudFront WAF returns 403 on `dp.la/thumb/...` when curl's default UA is used
- Added `-A "$BROWSER_UA"` to both `curl` calls, with `BROWSER_UA` extracted as a top-level constant to avoid duplication
- Updated comments to explain the WAF reason

## Test plan

- [ ] Deploy with `DEPLOY_THUMB=true` on a machine where the thumbnail API is healthy — pre-flight check should now return HTTP 200/302 instead of 403
- [ ] Post-deploy health check should pass without `thumbnail-api post-deploy health check failed` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Changes

Modified bin/deploy-api-services to ensure thumbnail health checks present a browser-like User-Agent when calling dp.la/thumb/...:

- Added a top-level BROWSER_UA constant (env-overrideable via BROWSER_UA or ${BROWSER_UA:-"..."}).
- Added -A "$BROWSER_UA" to the pre-flight and post-deploy curl calls that check https://dp.la/thumb/ee7d7c513000727d22613e1c6ba17061.
- Updated comments to explain the change (CloudFront WAF blocks curl's default User-Agent).
- Small commit making BROWSER_UA overrideable on deploy hosts.

Files changed: 1 (bin/deploy-api-services: +5/−2).

## Impact / Notes (explicit items requested)
- Manual pipeline trigger / ECS redeploy: No infrastructure change required. The change is only in the deploy script; it takes effect the next time you run this script (no CodePipeline or ECS redeploys are required beyond a normal run).
- Environment variables / Secrets: Adds a script-level BROWSER_UA constant and intentionally allows overriding it via the BROWSER_UA environment variable on deploy hosts. No new AWS Secrets Manager keys added/removed/renamed.
- Database migrations: None.
- Shared infrastructure config: None (no changes to CodePipeline, CodeBuild, ECS task definitions, IAM, etc.).
- Public API shape / endpoints: None.
- Security implications: Low. The script now sends a browser-like User-Agent string to the thumbnail endpoint; BROWSER_UA is overrideable by environment for operational flexibility. No credentials or sensitive data are introduced.

## Why
CloudFront WAF was returning HTTP 403 for dp.la/thumb/... when curl's default User-Agent was used. Presenting a browser-like UA prevents the WAF from blocking the health-check requests and avoids false-negative deploy failures.

## Test plan
- Run deploy with DEPLOY_THUMB=true on a machine where the thumbnail API is healthy. The pre-flight check should return HTTP 200/202/302 (not 403).
- After a deployment, the post-deploy thumbnail health check should pass without the "thumbnail-api post-deploy health check failed" error.

## Commits / metadata
- Commit includes making BROWSER_UA env-overrideable (useful if WAF behavior changes). Co-Authored-By metadata present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->