### PR TITLE
Return structured JSON objects for all error responses

### DIFF
--- a/src/main/scala/dpla/api/Routes.scala
+++ b/src/main/scala/dpla/api/Routes.scala
@@ -555,7 +555,11 @@ class Routes(
   )
 
   private def errorEntity(error: String, message: String): ResponseEntity = {
-    val json = Map("error" -> error, "message" -> message).toJson.toString
+    val json = Map(
+      "error" -> error,
+      "message" -> message,
+      "documentation" -> "https://pro.dp.la/developers/responses#errors"
+    ).toJson.toString
     HttpEntity(ContentTypes.`application/json`, json)
   }
 

--- a/src/main/scala/dpla/api/Routes.scala
+++ b/src/main/scala/dpla/api/Routes.scala
@@ -554,17 +554,16 @@ class Routes(
     RawHeader("X-Frame-Options", "DENY")
   )
 
-  private def jsonEntity(message: String): ResponseEntity = {
-    // Converting to json and back to string ensures that the string is
-    // encased in quotation marks, and external quotation marks are escaped.
-    val json = message.toJson.toString
+  private def errorEntity(error: String, message: String): ResponseEntity = {
+    val json = Map("error" -> error, "message" -> message).toJson.toString
     HttpEntity(ContentTypes.`application/json`, json)
   }
 
   private val internalErrorResponse: HttpResponse =
     HttpResponse(
       InternalServerError,
-      entity = jsonEntity(
+      entity = errorEntity(
+        "internal_error",
         "There was an unexpected internal error. Please try again later."
       )
     )
@@ -572,7 +571,8 @@ class Routes(
   private val notFoundResponse: HttpResponse =
     HttpResponse(
       NotFound,
-      entity = jsonEntity(
+      entity = errorEntity(
+        "not_found",
         "The record you are searching for could not be found."
       )
     )
@@ -580,7 +580,8 @@ class Routes(
   private val forbiddenResponse: HttpResponse =
     HttpResponse(
       Forbidden,
-      entity = jsonEntity(
+      entity = errorEntity(
+        "invalid_api_key",
         "Invalid or inactive API key."
       )
     )
@@ -588,23 +589,27 @@ class Routes(
   private def badRequestResponse(message: String): HttpResponse =
     HttpResponse(
       BadRequest,
-      entity = jsonEntity(message)
+      entity = errorEntity("bad_request", message)
     )
 
   private def existingKeyResponse(email: String): HttpResponse =
     HttpResponse(
       Conflict,
-      entity = jsonEntity(s"There is already an API key for $email" +
-        ". We have sent a reminder message to that address."
+      entity = errorEntity(
+        "existing_key",
+        s"There is already an API key for $email" +
+          ". We have sent a reminder message to that address."
       )
     )
 
   private def disabledKeyResponse(email: String): HttpResponse =
     HttpResponse(
       Conflict,
-      entity = jsonEntity(s"The API key associated with email address $email" +
-        " has been disabled. If you would like to reactivate it, " +
-        "please contact DPLA."
+      entity = errorEntity(
+        "disabled_key",
+        s"The API key associated with email address $email" +
+          " has been disabled. If you would like to reactivate it, " +
+          "please contact DPLA."
       )
     )
 


### PR DESCRIPTION
## Summary

All error responses previously returned a bare JSON string:
```json
"Invalid or inactive API key."
```

They now return a structured object with a machine-readable `error` code alongside the human-readable `message`:
```json
{"error": "invalid_api_key", "message": "Invalid or inactive API key."}
```

This makes error handling programmatic for API consumers and aligns with the WAF rate-limit error body already in production (`{"error": "rate_limit_exceeded", ...}`).

## Error codes

| Response | HTTP status | `error` code |
|---|---|---|
| Invalid/inactive API key | 403 | `invalid_api_key` |
| Record not found | 404 | `not_found` |
| Validation failure | 400 | `bad_request` |
| Key already exists | 409 | `existing_key` |
| Key disabled | 409 | `disabled_key` |
| Unexpected internal error | 500 | `internal_error` |

## Changes

Single change in `Routes.scala`: `jsonEntity(message)` → `errorEntity(error, message)`. All response message text is unchanged.

## Test plan

- [ ] `GET /items` with no API key → `403 {"error": "invalid_api_key", "message": "Invalid or inactive API key."}`
- [ ] `GET /items?page=abc` with valid API key → `400 {"error": "bad_request", "message": "..."}`
- [ ] `GET /items/nonexistent-id` → `404 {"error": "not_found", "message": "The record you are searching for could not be found."}`
- [ ] Force an internal error → `500 {"error": "internal_error", "message": "..."}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR modifies the error response format for the DPLA API by replacing plain JSON string responses with structured JSON objects containing a machine-readable "error" code, a human-readable "message", and a "documentation" URL.

## Key Changes
- File changed: src/main/scala/dpla/api/Routes.scala
- Replaced previous single-string JSON error payloads with errorEntity(error, message) which produces:
  {"error":"<code>","message":"<text>","documentation":"https://pro.dp.la/developers/responses#errors"}
- Error codes introduced/mapped:
  - 403 — invalid_api_key — "Invalid or inactive API key."
  - 404 — not_found — "The record you are searching for could not be found."
  - 400 — bad_request — validation failure messages (passed through)
  - 409 — existing_key — "There is already an API key for <email>..."
  - 409 — disabled_key — "The API key associated with email address <email> has been disabled..."
  - 500 — internal_error — "There was an unexpected internal error. Please try again later."
- Implementation is localized to Routes.scala (private helper replaced and private HttpResponse values updated). Message text preserved; JSON shape extended and documentation URL added.
- Tests: plan includes verifying 403, 400, 404, and 500 responses return the new structured JSON bodies.

## Impact Assessment
- Public-facing API response shape change: Yes. All error responses now return a structured JSON object with an "error" code, "message", and "documentation" URL. Clients that parse error responses must update parsing/handling accordingly.
- No endpoints added/removed.
- No changes to environment variables, AWS Secrets Manager keys, or database migrations.
- No shared infrastructure (CodePipeline/CodeBuild/ECS/IAM) modifications.
- No manual pipeline trigger or special ECS redeployment required beyond the normal release/deploy process.
- Security implications: None in authentication/credential handling; change is purely response formatting (but clients depending on previous string-only error bodies must update to avoid parsing issues).

## Commits
- Single commit: "Add documentation field to all error responses" (adds documentation URL and structured error format; co-authored).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->