### PR TITLE
Add Akka circuit breaker for ElasticSearch calls

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -63,6 +63,17 @@ elasticSearch {
   itemsUrl = ${?ITEM_ELASTICSEARCH_URL}
   pssUrl = ""
   pssUrl = ${?PSS_ELASTICSEARCH_URL}
+  circuitBreaker {
+    # Trip after this many consecutive call timeouts
+    maxFailures = 3
+    maxFailures = ${?ES_CIRCUIT_BREAKER_MAX_FAILURES}
+    # How long a single ES call may take before counting as a failure
+    callTimeout = 10s
+    callTimeout = ${?ES_CIRCUIT_BREAKER_CALL_TIMEOUT}
+    # How long to keep the breaker open before attempting ES again
+    resetTimeout = 20s
+    resetTimeout = ${?ES_CIRCUIT_BREAKER_RESET_TIMEOUT}
+  }
 }
 awsSes {
   emailFrom  = "info@dp.la"

--- a/src/main/scala/dpla/api/v2/search/ElasticSearchClient.scala
+++ b/src/main/scala/dpla/api/v2/search/ElasticSearchClient.scala
@@ -2,6 +2,7 @@ package dpla.api.v2.search
 
 import akka.actor.typed.{ActorRef, ActorSystem, Behavior}
 import akka.actor.typed.scaladsl.{Behaviors, LoggerOps}
+import akka.actor.typed.scaladsl.adapter.TypedSchedulerOps
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.{
   ContentTypes,
@@ -10,6 +11,7 @@ import akka.http.scaladsl.model.{
   HttpRequest,
   HttpResponse
 }
+import akka.pattern.CircuitBreaker
 import dpla.api.v2.search.ElasticSearchResponseHandler.{
   ElasticSearchResponseHandlerCommand,
   ProcessElasticSearchResponse
@@ -23,7 +25,9 @@ import dpla.api.v2.search.paramValidators.{
 import spray.json.JsValue
 
 import java.util.concurrent.{Semaphore, TimeUnit}
+import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.{ExecutionContext, Future}
+import scala.jdk.DurationConverters._
 import org.slf4j.LoggerFactory
 
 /** Sends requests to Elastic Search.
@@ -126,6 +130,19 @@ object ElasticSearchClient {
           "ElasticSearchResponseHandler"
         )
 
+      val cfg = context.system.settings.config.getConfig("elasticSearch.circuitBreaker")
+      val maxFailures: Int = cfg.getInt("maxFailures")
+      val callTimeout: FiniteDuration = cfg.getDuration("callTimeout").toScala.toCoarsest
+      val resetTimeout: FiniteDuration = cfg.getDuration("resetTimeout").toScala.toCoarsest
+      val breaker = CircuitBreaker(
+        scheduler    = context.system.scheduler.toClassic,
+        maxFailures  = maxFailures,
+        callTimeout  = callTimeout,
+        resetTimeout = resetTimeout
+      ).onOpen(() => context.log.warn("ElasticSearch circuit breaker opened"))
+       .onClose(() => context.log.info("ElasticSearch circuit breaker closed"))
+       .onHalfOpen(() => context.log.info("ElasticSearch circuit breaker half-open, testing ES"))
+
       Behaviors.receiveMessage[IntermediateSearchResult] {
 
         case SearchQuery(params, query, replyTo) =>
@@ -136,7 +153,8 @@ object ElasticSearchClient {
             endpoint,
             replyTo,
             responseHandler,
-            nextPhase
+            nextPhase,
+            breaker
           )
           context.spawnAnonymous(sessionChildActor)
           Behaviors.same
@@ -150,7 +168,8 @@ object ElasticSearchClient {
             endpoint,
             replyTo,
             responseHandler,
-            nextPhase
+            nextPhase,
+            breaker
           )
           context.spawnAnonymous(sessionChildActor)
           Behaviors.same
@@ -161,7 +180,8 @@ object ElasticSearchClient {
             endpoint,
             replyTo,
             responseHandler,
-            nextPhase
+            nextPhase,
+            breaker
           )
           context.spawnAnonymous(sessionChildActor)
           Behaviors.same
@@ -174,7 +194,8 @@ object ElasticSearchClient {
             endpoint,
             replyTo,
             responseHandler,
-            nextPhase
+            nextPhase,
+            breaker
           )
           context.spawnAnonymous(sessionChildActor)
           Behaviors.same
@@ -195,7 +216,8 @@ object ElasticSearchClient {
       endpoint: String,
       replyTo: ActorRef[SearchResponse],
       responseHandler: ActorRef[ElasticSearchResponseHandlerCommand],
-      nextPhase: ActorRef[IntermediateSearchResult]
+      nextPhase: ActorRef[IntermediateSearchResult],
+      breaker: CircuitBreaker
   ): Behavior[ElasticSearchResponse] = {
 
     Behaviors.setup { context =>
@@ -210,7 +232,7 @@ object ElasticSearchClient {
         entity = HttpEntity(ContentTypes.`application/json`, query.toString)
       )
       val futureResp: Future[HttpResponse] = withConcurrencyLimit {
-        Http().singleRequest(request)
+        breaker.withCircuitBreaker { Http().singleRequest(request) }
       }
 
       context.log.info2(
@@ -249,7 +271,8 @@ object ElasticSearchClient {
       endpoint: String,
       replyTo: ActorRef[SearchResponse],
       responseHandler: ActorRef[ElasticSearchResponseHandlerCommand],
-      nextPhase: ActorRef[IntermediateSearchResult]
+      nextPhase: ActorRef[IntermediateSearchResult],
+      breaker: CircuitBreaker
   ): Behavior[ElasticSearchResponse] = {
 
     Behaviors.setup { context =>
@@ -259,7 +282,7 @@ object ElasticSearchClient {
       // Make an HTTP request to elastic search.
       val fetchUri = s"$endpoint/_doc/$id"
       val futureResp: Future[HttpResponse] = withConcurrencyLimit {
-        Http().singleRequest(HttpRequest(uri = fetchUri))
+        breaker.withCircuitBreaker { Http().singleRequest(HttpRequest(uri = fetchUri)) }
       }
 
       context.log.info("ElasticSearch fetch QUERY: {}", fetchUri)
@@ -299,7 +322,8 @@ object ElasticSearchClient {
       endpoint: String,
       replyTo: ActorRef[SearchResponse],
       responseHandler: ActorRef[ElasticSearchResponseHandlerCommand],
-      nextPhase: ActorRef[IntermediateSearchResult]
+      nextPhase: ActorRef[IntermediateSearchResult],
+      breaker: CircuitBreaker
   ): Behavior[ElasticSearchResponse] = {
 
     Behaviors.setup { context =>
@@ -314,7 +338,7 @@ object ElasticSearchClient {
         entity = HttpEntity(ContentTypes.`application/json`, query.toString)
       )
       val futureResp: Future[HttpResponse] = withConcurrencyLimit {
-        Http().singleRequest(request)
+        breaker.withCircuitBreaker { Http().singleRequest(request) }
       }
 
       context.log.info2(
@@ -352,7 +376,8 @@ object ElasticSearchClient {
       endpoint: String,
       replyTo: ActorRef[SearchResponse],
       responseHandler: ActorRef[ElasticSearchResponseHandlerCommand],
-      nextPhase: ActorRef[IntermediateSearchResult]
+      nextPhase: ActorRef[IntermediateSearchResult],
+      breaker: CircuitBreaker
   ): Behavior[ElasticSearchResponse] = {
 
     Behaviors.setup { context =>
@@ -367,7 +392,7 @@ object ElasticSearchClient {
         entity = HttpEntity(ContentTypes.`application/json`, query.toString)
       )
       val futureResp: Future[HttpResponse] = withConcurrencyLimit {
-        Http().singleRequest(request)
+        breaker.withCircuitBreaker { Http().singleRequest(request) }
       }
 
       context.log.info2(

--- a/src/main/scala/dpla/api/v2/search/ElasticSearchResponseHandler.scala
+++ b/src/main/scala/dpla/api/v2/search/ElasticSearchResponseHandler.scala
@@ -2,11 +2,15 @@ package dpla.api.v2.search
 
 import akka.actor.typed.{ActorRef, ActorSystem, Behavior}
 import akka.actor.typed.scaladsl.Behaviors
+import akka.actor.typed.scaladsl.adapter.TypedSchedulerOps
 import akka.http.scaladsl.model.{HttpResponse, StatusCode}
 import akka.http.scaladsl.model.HttpMessage.DiscardedEntity
 import akka.http.scaladsl.unmarshalling.Unmarshaller
+import akka.pattern.CircuitBreaker
 
+import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.{ExecutionContextExecutor, Future}
+import scala.jdk.DurationConverters._
 import scala.util.{Failure, Success}
 
 /**
@@ -48,11 +52,28 @@ object ElasticSearchResponseHandler {
 
   def apply(): Behavior[ElasticSearchResponseHandlerCommand] = {
     Behaviors.setup { context =>
+
+      val cfg = context.system.settings.config.getConfig("elasticSearch.circuitBreaker")
+
+      val maxFailures: Int = cfg.getInt("maxFailures")
+      val callTimeout: FiniteDuration = cfg.getDuration("callTimeout").toScala.toCoarsest
+      val resetTimeout: FiniteDuration = cfg.getDuration("resetTimeout").toScala.toCoarsest
+
+      // If ES calls time out maxFailures times consecutively, stop sending
+      // requests for resetTimeout to let ES recover before retrying.
+      val breaker = CircuitBreaker(
+        scheduler    = context.system.scheduler.toClassic,
+        maxFailures  = maxFailures,
+        callTimeout  = callTimeout,
+        resetTimeout = resetTimeout
+      ).onOpen(() => context.log.warn("ElasticSearch circuit breaker opened"))
+       .onClose(() => context.log.info("ElasticSearch circuit breaker closed"))
+       .onHalfOpen(() => context.log.info("ElasticSearch circuit breaker half-open, testing ES"))
+
       Behaviors.receiveMessage[ElasticSearchResponseHandlerCommand] {
 
         case ProcessElasticSearchResponse(futureHttpResponse, replyTo) =>
-          // Map the Future value to a message, handled by this actor.
-          context.pipeToSelf(futureHttpResponse) {
+          context.pipeToSelf(breaker.withCircuitBreaker(futureHttpResponse)) {
             case Success(httpResponse) =>
               ProcessHttpResponse(httpResponse, replyTo)
             case Failure(e) =>

--- a/src/main/scala/dpla/api/v2/search/ElasticSearchResponseHandler.scala
+++ b/src/main/scala/dpla/api/v2/search/ElasticSearchResponseHandler.scala
@@ -2,15 +2,12 @@ package dpla.api.v2.search
 
 import akka.actor.typed.{ActorRef, ActorSystem, Behavior}
 import akka.actor.typed.scaladsl.Behaviors
-import akka.actor.typed.scaladsl.adapter.TypedSchedulerOps
 import akka.http.scaladsl.model.{HttpResponse, StatusCode}
 import akka.http.scaladsl.model.HttpMessage.DiscardedEntity
 import akka.http.scaladsl.unmarshalling.Unmarshaller
-import akka.pattern.CircuitBreaker
+import akka.pattern.CircuitBreakerOpenException
 
-import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.{ExecutionContextExecutor, Future}
-import scala.jdk.DurationConverters._
 import scala.util.{Failure, Success}
 
 /**
@@ -53,27 +50,10 @@ object ElasticSearchResponseHandler {
   def apply(): Behavior[ElasticSearchResponseHandlerCommand] = {
     Behaviors.setup { context =>
 
-      val cfg = context.system.settings.config.getConfig("elasticSearch.circuitBreaker")
-
-      val maxFailures: Int = cfg.getInt("maxFailures")
-      val callTimeout: FiniteDuration = cfg.getDuration("callTimeout").toScala.toCoarsest
-      val resetTimeout: FiniteDuration = cfg.getDuration("resetTimeout").toScala.toCoarsest
-
-      // If ES calls time out maxFailures times consecutively, stop sending
-      // requests for resetTimeout to let ES recover before retrying.
-      val breaker = CircuitBreaker(
-        scheduler    = context.system.scheduler.toClassic,
-        maxFailures  = maxFailures,
-        callTimeout  = callTimeout,
-        resetTimeout = resetTimeout
-      ).onOpen(() => context.log.warn("ElasticSearch circuit breaker opened"))
-       .onClose(() => context.log.info("ElasticSearch circuit breaker closed"))
-       .onHalfOpen(() => context.log.info("ElasticSearch circuit breaker half-open, testing ES"))
-
       Behaviors.receiveMessage[ElasticSearchResponseHandlerCommand] {
 
         case ProcessElasticSearchResponse(futureHttpResponse, replyTo) =>
-          context.pipeToSelf(breaker.withCircuitBreaker(futureHttpResponse)) {
+          context.pipeToSelf(futureHttpResponse) {
             case Success(httpResponse) =>
               ProcessHttpResponse(httpResponse, replyTo)
             case Failure(e) =>
@@ -117,12 +97,11 @@ object ElasticSearchResponseHandler {
         }
 
         case ReturnFinalResponse(response, replyTo, error) =>
-          // Log error if there is one
           error match {
+            case Some(_: CircuitBreakerOpenException) =>
+              context.log.warn("Request rejected: ElasticSearch circuit breaker is open")
             case Some(e) =>
-              context.log.error(
-                "Failed to process ElasticSearch response:", e
-              )
+              context.log.error("Failed to process ElasticSearch response:", e)
             case None => // no-op
           }
           // Send fully processed reply to original requester.


### PR DESCRIPTION
## Summary

- Wraps all ES calls in an Akka `CircuitBreaker` in `ElasticSearchResponseHandler`
- After `maxFailures` consecutive call timeouts, the breaker opens and immediately returns `ElasticSearchResponseFailure` for `resetTimeout`, giving ES breathing room without continued request pressure
- Logs state transitions (open / half-open / closed) for production visibility
- All three parameters configurable via env vars for tuning without a redeploy

## Configuration (with defaults)

| Env var | Default | Meaning |
|---|---|---|
| `ES_CIRCUIT_BREAKER_MAX_FAILURES` | `3` | Consecutive timeouts before opening |
| `ES_CIRCUIT_BREAKER_CALL_TIMEOUT` | `10s` | Per-call timeout |
| `ES_CIRCUIT_BREAKER_RESET_TIMEOUT` | `20s` | How long to stay open before retrying |

## Background

Resurrects [#34](https://github.com/dpla/api/pull/34) (shelved in 2022 pending performance testing), ported to the current `dpla.api.v2` package. Motivated by recurring ES flakiness under expensive bot-driven queries — the breaker prevents a struggling ES from being hammered further during recovery.

The `callTimeout` is set to 10s (vs. the original 3s) to avoid tripping on legitimately slow-but-valid queries under normal load.

## Test plan

- [ ] Confirm existing tests pass (`sbt test`)
- [ ] Deploy to staging and verify breaker state transitions appear in logs under simulated ES slowness
- [ ] Tune `ES_CIRCUIT_BREAKER_CALL_TIMEOUT` if needed based on observed p99 ES latency

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Add Akka circuit breaker for ElasticSearch calls

Wraps ElasticSearch calls with an Akka CircuitBreaker to protect ES from cascading failures and reduce pressure during ES slowness/outages.

### Changes

- Configuration (src/main/resources/application.conf):
  - Adds elasticSearch.circuitBreaker with:
    - maxFailures (default 3 — override via ES_CIRCUIT_BREAKER_MAX_FAILURES)
    - callTimeout (default 10s — override via ES_CIRCUIT_BREAKER_CALL_TIMEOUT)
    - resetTimeout (default 20s — override via ES_CIRCUIT_BREAKER_RESET_TIMEOUT)
  - Call timeout increased to 10s to reduce false trips on slow-but-valid queries.

- Implementation:
  - CircuitBreaker is constructed in ElasticSearchClient using the new config and logs state transitions:
    - onOpen logs "ElasticSearch circuit breaker opened" (warn)
    - onHalfOpen logs "ElasticSearch circuit breaker half-open, testing ES" (info)
    - onClose logs "ElasticSearch circuit breaker closed" (info)
  - The breaker is passed into per-request session behaviors (search, fetch, multi-fetch, random).
  - Each ES HTTP request is executed as breaker.withCircuitBreaker { Http().singleRequest(request) } wrapped inside the existing withConcurrencyLimit, so when the breaker is open the request is short-circuited and the HTTP request is not sent.
  - ElasticSearchResponseHandler now special-cases CircuitBreakerOpenException and logs "Request rejected: ElasticSearch circuit breaker is open" at warn level; rejected requests are mapped to ElasticSearchResponseFailure as before.

- Concurrency behavior:
  - Existing semaphore-based concurrency limiter (ES_MAX_CONCURRENT_REQUESTS, default 32) remains in place and continues to cap in-flight ES requests per API instance.

### Environment Variables / Secrets

- Adds three tunable environment variables (no removals or renames):
  - ES_CIRCUIT_BREAKER_MAX_FAILURES (default 3)
  - ES_CIRCUIT_BREAKER_CALL_TIMEOUT (default 10s)
  - ES_CIRCUIT_BREAKER_RESET_TIMEOUT (default 20s)
- No new AWS Secrets Manager keys were added or changed.

### Deployment & Operational Notes

- Requires redeploy to take effect: merging to main does not auto-deploy. After merge, trigger the repo's deploy workflow / CodePipeline / ECS deployment (repo uses manual dispatch for deploys).
- Runtime tuning: monitor staging/production logs for circuit-breaker state transitions and adjust ES_CIRCUIT_BREAKER_CALL_TIMEOUT / ES_CIRCUIT_BREAKER_MAX_FAILURES / ES_CIRCUIT_BREAKER_RESET_TIMEOUT based on observed p99 ES latency and failure characteristics.

### Testing

- Run existing tests (sbt test).
- In staging, simulate ES slowness to verify breaker opens, half-opens, and closes, and that rejected requests result in ElasticSearchResponseFailure without sending requests to ES.

### Impact Summary

- No database migrations.
- No changes to public API response shapes or endpoints.
- No changes to shared infra (CodePipeline/CodeBuild/ECS task definitions/IAM) in this PR — only application code and config.
- Security: no new credential handling or auth changes introduced. Logs now include circuit-breaker state transitions for visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->