### PR TITLE
fix: return 400 for Elasticsearch query parse errors instead of 500

### DIFF
--- a/src/main/scala/dpla/api/v2/registry/SearchRegistryBehavior.scala
+++ b/src/main/scala/dpla/api/v2/registry/SearchRegistryBehavior.scala
@@ -40,6 +40,8 @@ final case class RegisterRandom(
 
 trait SearchRegistryBehavior {
 
+  private val QueryParseErrorMessage = "The q parameter contains invalid search syntax."
+
   def spawnSearchActor(context: ActorContext[SearchRegistryCommand]):
     ActorRef[SearchCommand]
 
@@ -183,6 +185,10 @@ trait SearchRegistryBehavior {
           searchResponse = Some(NotFoundFailure)
           possibleSessionResolution
 
+        case SearchQueryParseFailure =>
+          searchResponse = Some(ValidationFailure(QueryParseErrorMessage))
+          possibleSessionResolution
+
         case SearchFailure =>
           searchResponse = Some(InternalFailure)
           possibleSessionResolution
@@ -298,6 +304,10 @@ trait SearchRegistryBehavior {
           fetchResponse = Some(NotFoundFailure)
           possibleSessionResolution
 
+        case SearchQueryParseFailure =>
+          fetchResponse = Some(InternalFailure)
+          possibleSessionResolution
+
         case SearchFailure =>
           fetchResponse = Some(InternalFailure)
           possibleSessionResolution
@@ -381,6 +391,10 @@ trait SearchRegistryBehavior {
 
         case InvalidSearchParams(message) =>
           randomResponse = Some(ValidationFailure(message))
+          possibleSessionResolution
+
+        case SearchQueryParseFailure =>
+          randomResponse = Some(ValidationFailure(QueryParseErrorMessage))
           possibleSessionResolution
 
         case SearchFailure =>

--- a/src/main/scala/dpla/api/v2/search/ElasticSearchClient.scala
+++ b/src/main/scala/dpla/api/v2/search/ElasticSearchClient.scala
@@ -228,8 +228,11 @@ object ElasticSearchClient {
           nextPhase ! SearchQueryResponse(params, body, replyTo)
           Behaviors.stopped
 
-        case ElasticSearchHttpError(_) =>
-          replyTo ! SearchFailure
+        case ElasticSearchHttpError(statusCode) =>
+          if (statusCode.intValue == 400)
+            replyTo ! SearchQueryParseFailure
+          else
+            replyTo ! SearchFailure
           Behaviors.stopped
 
         case ElasticSearchResponseFailure =>
@@ -385,8 +388,11 @@ object ElasticSearchClient {
           nextPhase ! RandomQueryResponse(params, body, replyTo)
           Behaviors.stopped
 
-        case ElasticSearchHttpError(_) =>
-          replyTo ! SearchFailure
+        case ElasticSearchHttpError(statusCode) =>
+          if (statusCode.intValue == 400)
+            replyTo ! SearchQueryParseFailure
+          else
+            replyTo ! SearchFailure
           Behaviors.stopped
 
         case ElasticSearchResponseFailure =>

--- a/src/main/scala/dpla/api/v2/search/SearchProtocol.scala
+++ b/src/main/scala/dpla/api/v2/search/SearchProtocol.scala
@@ -52,6 +52,7 @@ object SearchProtocol {
   final case object FetchNotFound extends SearchResponse
   final case object SearchNotFound extends SearchResponse
   final case object SearchFailure extends SearchResponse
+  final case object SearchQueryParseFailure extends SearchResponse
 
   /**
    * Internal command protocol.

--- a/src/test/scala/dpla/api/v2/endToEnd/InvalidParamsTest.scala
+++ b/src/test/scala/dpla/api/v2/endToEnd/InvalidParamsTest.scala
@@ -8,7 +8,8 @@ import akka.http.scaladsl.testkit.ScalatestRouteTest
 import dpla.api.Routes
 import dpla.api.helpers.ActorHelper
 import dpla.api.helpers.Utils.fakeApiKey
-import dpla.api.v2.registry.{MockSmrRegistry, SmrRegistryCommand}
+import dpla.api.v2.registry.{MockItemRegistry, MockSmrRegistry, SmrRegistryCommand}
+import dpla.api.v2.search.{MockEsClientQueryParseError, MockItemSearch}
 import dpla.api.v2.smr.MockSmrRequestHandler
 import dpla.api.v2.smr.SmrProtocol.SmrCommand
 import org.scalatest.matchers.should.Matchers
@@ -33,6 +34,17 @@ class InvalidParamsTest extends AnyWordSpec with Matchers
 
   lazy val routes: Route =
     new Routes(itemRegistry, pssRegistry, apiKeyRegistry,
+      smrRegistryS3Success).applicationRoutes
+
+  val esQueryParseErrorClient =
+    testKit.spawn(MockEsClientQueryParseError())
+  val itemSearchWithParseError =
+    MockItemSearch(testKit, Some(esQueryParseErrorClient))
+  val itemRegistryWithParseError =
+    MockItemRegistry(testKit, authenticator, itemAnalyticsClient,
+      Some(itemSearchWithParseError))
+  val routesWithParseError: Route =
+    new Routes(itemRegistryWithParseError, pssRegistry, apiKeyRegistry,
       smrRegistryS3Success).applicationRoutes
 
   "malformed api_key" should {
@@ -88,6 +100,16 @@ class InvalidParamsTest extends AnyWordSpec with Matchers
       val request = Post("/v2/api_key/foo")
 
       request ~> Route.seal(routes) ~> check {
+        status shouldEqual StatusCodes.BadRequest
+        contentType should === (ContentTypes.`application/json`)
+      }
+    }
+  }
+
+  "Elasticsearch query parse error" should {
+    "return BadRequest for /v2/items" in {
+      val request = Get(s"/v2/items?api_key=$fakeApiKey&q=invalid%29-")
+      request ~> Route.seal(routesWithParseError) ~> check {
         status shouldEqual StatusCodes.BadRequest
         contentType should === (ContentTypes.`application/json`)
       }

--- a/src/test/scala/dpla/api/v2/search/MockEsClientQueryParseError.scala
+++ b/src/test/scala/dpla/api/v2/search/MockEsClientQueryParseError.scala
@@ -1,0 +1,29 @@
+package dpla.api.v2.search
+
+import akka.actor.typed.Behavior
+import akka.actor.typed.scaladsl.Behaviors
+import dpla.api.v2.search.SearchProtocol.{
+  IntermediateSearchResult,
+  RandomQuery,
+  SearchQuery,
+  SearchQueryParseFailure
+}
+
+object MockEsClientQueryParseError {
+
+  def apply(): Behavior[IntermediateSearchResult] = {
+    Behaviors.receiveMessage[IntermediateSearchResult] {
+
+      case SearchQuery(_, _, replyTo) =>
+        replyTo ! SearchQueryParseFailure
+        Behaviors.same
+
+      case RandomQuery(_, _, replyTo) =>
+        replyTo ! SearchQueryParseFailure
+        Behaviors.same
+
+      case _ =>
+        Behaviors.unhandled
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Malformed Lucene syntax in the `q` parameter (e.g. MARC bibliographic subject headings with trailing `)-` like `García,, Eloy,, 1958)-`) causes Elasticsearch to return HTTP 400. Previously `ElasticSearchClient.processSearch` and `processRandom` used a wildcard `case ElasticSearchHttpError(_)` that discarded the status code and mapped all non-200 ES responses to `SearchFailure` → HTTP 500.
- Added `SearchQueryParseFailure` to `SearchProtocol` and updated `processSearch`/`processRandom` in `ElasticSearchClient` to emit it when ES returns 400 (mirroring how `processFetch` already handles 404).
- Wired `SearchQueryParseFailure` through `SearchRegistryBehavior` → `ValidationFailure("The q parameter contains invalid search syntax.")` → HTTP 400 with JSON body for search and random paths; added a defensive handler in the fetch path.
- Added `MockEsClientQueryParseError` and an end-to-end test asserting `/v2/items?q=invalid%29-` returns 400.

## Root cause

Observed in production: a Basque library scraper (`Jakarta Commons-HttpClient/3.1`) sending MARC subject headings as Lucene queries, generating 7 HTTP 500s that should have been 400s. The ES 400 responses were silently swallowed and re-emitted as 500s.

## Test plan

- [x] `sbt "compile; test"` passes (274/274)
- [x] New end-to-end test: `Elasticsearch query parse error` → `return BadRequest for /v2/items`
- [x] Existing tests for `SearchFailure` (non-400 ES errors) unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This PR fixes incorrect HTTP status codes returned when Elasticsearch receives malformed Lucene query syntax in the `q` parameter. Previously, Elasticsearch 400 responses were being converted to HTTP 500 errors; the fix ensures these now correctly return HTTP 400 with a descriptive validation error message. This resolves an issue where certain valid use cases (e.g., MARC subject headings with trailing punctuation like `García,, Eloy,, 1958)-`) were being rejected with 500 errors instead of 400 validation failures.

## Changes

### Core Changes
- **Protocol Update**: Added a new `SearchQueryParseFailure` response type to the `SearchProtocol` sealed trait to distinguish ES 400 errors from other search failures.
- **Error Handling**: Updated `ElasticSearchClient.processSearch()` and `processRandom()` to explicitly match HTTP 400 status codes from Elasticsearch and respond with `SearchQueryParseFailure` (consistent with how `processFetch` handles 404 errors); all other HTTP errors continue to return `SearchFailure`.
- **Registry Behavior**: Propagated `SearchQueryParseFailure` through `SearchRegistryBehavior` to convert it to `ValidationFailure("The q parameter contains invalid search syntax.")` for the `/v2/items` search and random endpoints, producing HTTP 400 responses with JSON error bodies. Added a defensive handler in the fetch path for completeness.

### Testing
- Added `MockEsClientQueryParseError` to simulate Elasticsearch 400 responses in tests.
- Added end-to-end test validating that `/v2/items?q=invalid%29-` returns HTTP 400 with appropriate error message.
- All 274 existing tests pass; no regression in error handling for other HTTP status codes.

## Public API Changes
**Modifies public-facing API response shape**: The `/v2/items` search and random endpoints now return HTTP 400 (BadRequest) instead of HTTP 500 (InternalServerError) when the `q` parameter contains invalid Lucene query syntax. Error response body format remains consistent with other validation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->