### PR TITLE
fix: use SLF4J logger in circuit breaker callbacks (fixes missing state-transition logs)

### DIFF
--- a/src/main/scala/dpla/api/v2/search/ElasticSearchClient.scala
+++ b/src/main/scala/dpla/api/v2/search/ElasticSearchClient.scala
@@ -139,9 +139,9 @@ object ElasticSearchClient {
         maxFailures  = maxFailures,
         callTimeout  = callTimeout,
         resetTimeout = resetTimeout
-      ).onOpen(() => context.log.warn("ElasticSearch circuit breaker opened"))
-       .onClose(() => context.log.info("ElasticSearch circuit breaker closed"))
-       .onHalfOpen(() => context.log.info("ElasticSearch circuit breaker half-open, testing ES"))
+      ).onOpen(() => log.warn("ElasticSearch circuit breaker opened"))
+       .onClose(() => log.info("ElasticSearch circuit breaker closed"))
+       .onHalfOpen(() => log.info("ElasticSearch circuit breaker half-open, testing ES"))
 
       Behaviors.receiveMessage[IntermediateSearchResult] {
 


### PR DESCRIPTION
## Root cause

`CircuitBreaker.onOpen`/`onHalfOpen`/`onClose` callbacks were logging via `context.log` (Akka Typed's `ActorLogger`). Those callbacks fire on a Future dispatcher thread — not the actor's message-processing thread. Akka Typed's `ActorLogger` is not thread-safe: it's guarded by an internal actor-thread check, and when accessed from outside the actor loop it silently drops the message (or throws an `AssertionError` that is swallowed by the Future chain).

This is why the `ElasticSearchResponseHandler` rejection warning *was* appearing (logged inside `receiveMessage`, safe) while the three state-transition lines from `ElasticSearchClient` were never appearing — despite 24k rejections proving the breaker was cycling.

## Fix

Replace `context.log` in the three callbacks with the object-level `log` (`LoggerFactory.getLogger(getClass)`, already declared at line 37 of `ElasticSearchClient`). A plain SLF4J `Logger` is thread-safe and works correctly from any thread.

```scala
// Before — context.log is unsafe off the actor thread
).onOpen(() => context.log.warn("ElasticSearch circuit breaker opened"))
 .onClose(() => context.log.info("ElasticSearch circuit breaker closed"))
 .onHalfOpen(() => context.log.info("ElasticSearch circuit breaker half-open, testing ES"))

// After — SLF4J logger is thread-safe from any thread
).onOpen(() => log.warn("ElasticSearch circuit breaker opened"))
 .onClose(() => log.info("ElasticSearch circuit breaker closed"))
 .onHalfOpen(() => log.info("ElasticSearch circuit breaker half-open, testing ES"))
```

## Verification

After deploying, `aws logs filter-log-events --log-group-name /ecs/api --filter-pattern '"circuit breaker opened"'` should return results when the breaker trips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR fixes missing circuit breaker state-transition logs in the ElasticSearch client by replacing thread-unsafe Akka actor logging with thread-safe SLF4J logging in circuit breaker callbacks.

### Root Cause
The `CircuitBreaker.onOpen()`, `onClose()`, and `onHalfOpen()` callbacks were using Akka Typed's `context.log` (ActorLogger). Since these callbacks execute on Future dispatcher threads rather than the actor's message-processing thread, and ActorLogger is not thread-safe with built-in actor-thread checks, log messages were silently dropped or errors were swallowed by the Future chain.

### Changes
Updated three circuit breaker event callbacks in `ElasticSearchClient.scala` (lines 142-144) to use the existing object-level SLF4J logger instance instead of `context.log`:
- `onOpen()`: `.onOpen(() => log.warn(...))`
- `onClose()`: `.onClose(() => log.info(...))`
- `onHalfOpen()`: `.onHalfOpen(() => log.info(...))`

The log levels and message strings remain unchanged; only the logging mechanism was swapped. SLF4J's Logger is thread-safe and can be safely called from any thread.

### Deployment
This is a standard code change with no operational requirements. It will be deployed through the normal CI/CD pipeline and does not require manual pipeline triggers, ECS redeployment commands, or infrastructure configuration changes.

### Verification
After deployment, circuit breaker state transitions should now be visible in logs. CloudWatch Logs filter queries for "circuit breaker opened" will return results when the breaker trips.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->