### PR TITLE
Fix minor code quality issues (AI findings)

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -41,7 +41,7 @@ postgres {
     serverName = "localhost"
     serverName = ${?POSTGRES_SERVER}
     portNumber = "5432"
-    postNumber = ${?POSTGRES_PORT}
+    portNumber = ${?POSTGRES_PORT}
     databaseName = "dplaapi"
     databaseName = ${?POSTGRES_DB}
     user = "dplaapi"

--- a/src/main/scala/dpla/api/v2/search/ElasticSearchResponseHandler.scala
+++ b/src/main/scala/dpla/api/v2/search/ElasticSearchResponseHandler.scala
@@ -11,7 +11,7 @@ import scala.concurrent.{ExecutionContextExecutor, Future}
 import scala.util.{Failure, Success}
 
 /**
- * Processes response streams from Elastic Search.
+ * Processes response streams from Elasticsearch.
  */
 
 sealed trait ElasticSearchResponse

--- a/src/test/scala/dpla/api/v2/search/paramValidators/ParamValidatorTest.scala
+++ b/src/test/scala/dpla/api/v2/search/paramValidators/ParamValidatorTest.scala
@@ -735,7 +735,7 @@ class ParamValidatorTest extends AnyWordSpec with Matchers
 
     "reject too-short param" in {
       val given = "d"
-      val params =  Map("sourceResource.subject.name" -> given)
+      val params = Map("sourceResource.subject.name" -> given)
       itemParamValidator ! RawSearchParams(params, replyProbe.ref)
       replyProbe.expectMessageType[InvalidSearchParams]
     }


### PR DESCRIPTION
## Summary

Three minor fixes from GitHub AI code quality findings:

- **`application.conf`**: Fix typo `postNumber` → `portNumber` (line 44 was a duplicate key with wrong spelling — the env var `POSTGRES_PORT` was never actually applied)
- **`ElasticSearchResponseHandler.scala`**: Correct "Elastic Search" → "Elasticsearch" in Scaladoc comment
- **`ParamValidatorTest.scala`**: Remove extra space after `=` for consistent formatting

## Test plan

- [ ] Existing tests pass (no logic changed)
- [ ] Verify Postgres port env var (`POSTGRES_PORT`) now correctly overrides the default in deployed config

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR contains three minor code quality improvements:

1. **configuration.conf**: Fixed a typo in the PostgreSQL configuration where `postNumber` (with incorrect spelling) was replaced with the correct `portNumber` key to properly apply the `POSTGRES_PORT` environment variable in deployments.

2. **ElasticSearchResponseHandler.scala**: Corrected documentation comment spelling from "Elastic Search" to "Elasticsearch" (official product name).

3. **ParamValidatorTest.scala**: Removed extraneous whitespace in the "subject validator" → "reject too-short param" test case for consistent formatting.

## Deployment considerations

**Requires ECS redeployment**: The PostgreSQL port configuration fix must be deployed to production for the `POSTGRES_PORT` environment variable to properly override the default port value in the application configuration. This is a functional configuration change, not a no-op.

## Impact

- **No logic changes** — all modifications are configuration/documentation/formatting fixes
- **Test coverage**: Existing tests pass without modification
- **No API changes**: Public response shapes and endpoints unaffected
- **No infrastructure changes**: CodePipeline, CodeBuild, ECS task definitions, and IAM policies remain unchanged

<!-- end of auto-generated comment: release notes by coderabbit.ai -->