### PR TITLE
Return uniform 200 response for new and existing API key registrations

### DIFF
--- a/src/main/scala/dpla/api/Routes.scala
+++ b/src/main/scala/dpla/api/Routes.scala
@@ -410,9 +410,9 @@ class Routes(
       case SmrArchiveSuccess =>
         complete(smrArchiveSuccessMessage)
       case NewApiKey(email) =>
-        complete(newKeyMessage(email))
+        complete(apiKeyMessage(email))
       case ExistingApiKey(email) =>
-        complete(existingKeyResponse(email))
+        complete(apiKeyMessage(email))
       case DisabledApiKey(email) =>
         complete(disabledKeyResponse(email))
       case NotFoundFailure =>
@@ -506,16 +506,6 @@ class Routes(
       entity = errorEntity("bad_request", message)
     )
 
-  private def existingKeyResponse(email: String): HttpResponse =
-    HttpResponse(
-      Conflict,
-      entity = errorEntity(
-        "existing_key",
-        s"There is already an API key for $email" +
-          ". We have sent a reminder message to that address."
-      )
-    )
-
   private def disabledKeyResponse(email: String): HttpResponse =
     HttpResponse(
       Conflict,
@@ -527,8 +517,8 @@ class Routes(
       )
     )
 
-  private def newKeyMessage(email: String): String =
-    s"API key created and sent to $email."
+  private def apiKeyMessage(email: String): String =
+    s"Your API key has been sent to $email."
 
   private val smrArchiveSuccessMessage: String =
     s"Your request has been received."

--- a/src/test/scala/dpla/api/v2/authentication/MockPostgresClientExistingKey.scala
+++ b/src/test/scala/dpla/api/v2/authentication/MockPostgresClientExistingKey.scala
@@ -22,8 +22,8 @@ object MockPostgresClientExistingKey {
       case ValidApiKey(_, _) =>
         Behaviors.unhandled
 
-      case ValidEmail(_, replyTo) =>
-        replyTo ! AccountFound(account)
+      case ValidEmail(email, replyTo) =>
+        replyTo ! AccountFound(account.copy(email = email))
         Behaviors.same
 
       case _ =>

--- a/src/test/scala/dpla/api/v2/endToEnd/PostgresErrorTest.scala
+++ b/src/test/scala/dpla/api/v2/endToEnd/PostgresErrorTest.scala
@@ -44,7 +44,7 @@ class PostgresErrorTest extends AnyWordSpec with Matchers
   }
 
   "/api_key/[email] route" should {
-    "return Conflict if email has existing api key" in {
+    "return OK if email has existing api key" in {
       lazy val routes: Route =
         new Routes(itemRegistry, pssRegistry,
           apiKeyRegistryExistingKey, smrRegistry).applicationRoutes
@@ -52,8 +52,8 @@ class PostgresErrorTest extends AnyWordSpec with Matchers
       val request = Post("/v2/api_key/email@example.com")
 
       request ~> Route.seal(routes) ~> check {
-        status shouldEqual StatusCodes.Conflict
-        contentType should === (ContentTypes.`application/json`)
+        status shouldEqual StatusCodes.OK
+        entityAs[String] shouldEqual "Your API key has been sent to email@example.com."
       }
     }
   }


### PR DESCRIPTION
## Summary

The `POST /api_key/:email` endpoint currently returns **HTTP 200** when registering a new account and **HTTP 409** when the email already exists. This difference is a user enumeration oracle — any caller can determine whether an arbitrary email address is registered with DPLA by observing the status code.

This PR closes that gap by returning **HTTP 200** with the same response body (`"Your API key has been sent to $email."`) for both the new-account and existing-account cases.

### Changes

- `Routes.scala`: `ExistingApiKey` now calls `apiKeyMessage` instead of `existingKeyResponse` (which returned 409 Conflict)
- `existingKeyResponse` method removed (no longer referenced)
- `newKeyMessage` renamed to `apiKeyMessage` with neutral wording ("Your API key has been sent to..." rather than "API key created and sent to...")

### Background

Discovered during a scanner investigation (2026-05-12): an automated scanner was calling `POST /api_key/` at scale against lists of email addresses — including real `@openai.com` addresses — and using the 200 vs 409 response to enumerate registered users. The uniform response removes the signal without affecting any legitimate use of the endpoint.

The `DisabledApiKey` (409) path is unchanged — disabled-account handling is a separate concern.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Security Fix: User Enumeration Prevention

This PR fixes a user-enumeration vulnerability in the API key registration endpoint. Previously POST /api_key/:email returned 200 for new accounts and 409 Conflict for existing accounts, allowing attackers to distinguish registered emails by status code.

## Changes

- Both NewApiKey(email) and ExistingApiKey(email) now return HTTP 200 with the same response body: "Your API key has been sent to $email."
- Renamed newKeyMessage() to apiKeyMessage() and used for both new and existing-key paths.
- Removed existingKeyResponse(), which previously returned 409 for existing keys.
- DisabledApiKey(email) behavior unchanged (still returns 409).
- Tests updated:
  - src/test/scala/dpla/api/v2/endToEnd/PostgresErrorTest.scala now expects 200 and the unified message for the existing-key case.
  - src/test/scala/dpla/api/v2/authentication/MockPostgresClientExistingKey.scala mock now returns AccountFound(account.copy(email = email)) for ValidEmail to reflect the email echo in the message.

Files changed (high-level):
- src/main/scala/dpla/api/Routes.scala
- src/test/scala/dpla/api/v2/endToEnd/PostgresErrorTest.scala
- src/test/scala/dpla/api/v2/authentication/MockPostgresClientExistingKey.scala

## Impact Notes

- Public-facing API change: The endpoint's status code for existing emails changed from 409 -> 200 while keeping the same message body. Clients that rely on a 409 to detect existing accounts must be updated.
- Security: This is a security fix to prevent account enumeration and should be treated accordingly.
- Deploy/Operational: Requires deploying the updated service (CI pipeline/ECS task redeploy) for the change to take effect. No changes to pipelines or deployment definitions themselves.
- Infrastructure and Secrets: No environment variables, AWS Secrets Manager keys, IAM policies, CodePipeline/CodeBuild/ECS task definitions, or other shared infra configurations were added, removed, or modified.
- Database: No database migrations were introduced.
- Backwards compatibility: Behavior is intentionally changed to close an information leak; review client code that inspects HTTP status codes for this endpoint.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/api/pull/110)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->